### PR TITLE
.gitignore file and a new overload for Search in BaseLuceneSearcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+*.add
+_ReSharper*
+*.suo
+[Dd]ebug/
+[Rr]elease/
+x64/
+build/
+[Bb]in/
+[Oo]bj/
+*ReSharper.user
+TestResults/*
+Examine.Web.Demo/App_Data/*
+*.user
+build/Releases/*
+packages/*

--- a/Projects/Examine/LuceneEngine/Providers/BaseLuceneSearcher.cs
+++ b/Projects/Examine/LuceneEngine/Providers/BaseLuceneSearcher.cs
@@ -157,6 +157,15 @@ namespace Examine.LuceneEngine.Providers
         [SecuritySafeCritical]
         public override ISearchResults Search(ISearchCriteria searchParams)
         {
+            return Search(searchParams, 0);
+        }
+
+        /// <summary>
+        /// Performs a search with a maximum number of results
+        /// </summary>        
+        [SecuritySafeCritical]
+        public ISearchResults Search(ISearchCriteria searchParams, int maxResults)
+        {
             var searcher = GetSearcher();
 
             Enforcer.ArgumentNotNull(searchParams, "searchParams");
@@ -165,7 +174,7 @@ namespace Examine.LuceneEngine.Providers
             if (luceneParams == null)
                 throw new ArgumentException("Provided ISearchCriteria dos not match the allowed ISearchCriteria. Ensure you only use an ISearchCriteria created from the current SearcherProvider");
 
-            var pagesResults = new SearchResults(luceneParams.Query, luceneParams.SortFields, searcher);
+            var pagesResults = new SearchResults(luceneParams.Query, luceneParams.SortFields, searcher, maxResults);
             return pagesResults;
         }
 


### PR DESCRIPTION
Added a new .gitignore file, tried to match the old .hgignore but
updated the syntax. Added an overload for Search in the
BaseLuceneSearcher to take a maxResults parameter to limit the number of
results returned from Lucene.
