### PR TITLE
Fixed maxResults bug

### DIFF
--- a/Projects/Examine/LuceneEngine/SearchResults.cs
+++ b/Projects/Examine/LuceneEngine/SearchResults.cs
@@ -94,7 +94,7 @@ namespace Examine.LuceneEngine
                 //swallow this exception, we should continue if this occurs.
             }
 
-		    maxResults = maxResults > 1 ? maxResults : LuceneSearcher.MaxDoc();
+		    maxResults = maxResults >= 1 ? maxResults : LuceneSearcher.MaxDoc();
 
             if (sortField.Count() == 0)
             {


### PR DESCRIPTION
maxResults was ignored if <= 1.

Calling searchProvider.Search(myCriteria, 1) returned more than 1 document.
Calling searchProvider.Search(myCriteria, 2) returned exactly 2 documents.
