### PR TITLE
Conversion issue with "," decimal separator

### DIFF
--- a/Projects/Examine/LuceneEngine/Providers/LuceneIndexer.cs
+++ b/Projects/Examine/LuceneEngine/Providers/LuceneIndexer.cs
@@ -1320,7 +1320,10 @@ namespace Examine.LuceneEngine.Providers
                             if (!_cancellationTokenSource.IsCancellationRequested)
                             {
                                 _asyncTask = Task.Factory.StartNew(
-                                    StartIndexing,
+                                    () => {
+					System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+					StartIndexing();
+	                            },
                                     _cancellationTokenSource.Token,  //use our cancellation token
                                     TaskCreationOptions.None,
                                     TaskScheduler.Default).ContinueWith(task =>


### PR DESCRIPTION
I found another issue where Examine do index of Double or Float values, and CurrentCulture uses "," as decimal separator.

I do hard debug to find the wrong code row, but i does not found. I have suspect that the issue is in Lucene.NET.

Whatever, I found a little work around to solve the issue. The issue can be solved simply force use of InvariantCulture during the index process.
This work around will work only when "RunAsync = True".
To solve the issue with "RunAsync = False" I suggest to create a parallel Thread, then wait the end of it. I have not practice with multithread, then I have not do this.

Thanks