### PR TITLE
Lucene issue on data indexing in "it-IT" culture

### DIFF
--- a/Projects/Examine/LuceneEngine/Providers/LuceneIndexer.cs
+++ b/Projects/Examine/LuceneEngine/Providers/LuceneIndexer.cs
@@ -1333,6 +1333,7 @@ namespace Examine.LuceneEngine.Providers
             if (!RunAsync)
             {
                 StartIndexing();
+                //NOTE: `StartIndexing()` method would to be call in `InvariantCulture`
             }
             else
             {
@@ -1347,7 +1348,10 @@ namespace Examine.LuceneEngine.Providers
                             if (!_cancellationTokenSource.IsCancellationRequested)
                             {
                                 _asyncTask = Task.Factory.StartNew(
-                                    StartIndexing,
+                                    () => {
+                                        System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+                                        StartIndexing();
+	                            },
                                     _cancellationTokenSource.Token,  //use our cancellation token
                                     TaskCreationOptions.None,
                                     TaskScheduler.Default).ContinueWith(task =>


### PR DESCRIPTION
I found an issue in data indexing when current culture do not use DOT char as decimal separator (example: the decimal separator in Italian culture is Comma char).

I think that the issue is inside Lucene.NET. I do not found the bug, but I found a work around that works properly.

The solution is to invoke `StartIndexing` of "Examine.LuceneEngine.Providers.LuceneIndexer" class with Invariant Culture.  
The method is invoked in 2 line code. The first is to index data in syncronous mode, the second is in asyncronous mode.  

This patch solve for asyncronous mode.  
To solve the syncronous mode I suggest to create a new syncronous Task, then set Invariant Culture before invoke `StartIndexing` method. But I have not experience in syncronous Task.