### PR TITLE
Case-insensitive Dictionary for Index Fields

### DIFF
--- a/Projects/Examine/LuceneEngine/Providers/LuceneIndexer.cs
+++ b/Projects/Examine/LuceneEngine/Providers/LuceneIndexer.cs
@@ -1054,7 +1054,7 @@ namespace Examine.LuceneEngine.Providers
         /// <returns></returns>
         protected virtual Dictionary<string, string> GetDataToIndex(XElement node, string type)
         {
-            var values = new Dictionary<string, string>();
+            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             var nodeId = int.Parse(node.Attribute("id").Value);
 


### PR DESCRIPTION
Makes the index-fields dictionary to have case-insensitive keys.

This came about when hooking into the `GatheringNodeData` event.

Take the following code... checks if a "tags" field exists, then processes it.

```csharp
var indexer = ExamineManager.Instance.IndexProviderCollection["MyIndexer"];
indexer.GatheringNodeData += (sender, e) =>
{
	if (e.Fields.ContainsKey("tags"))
	{
		e.Fields["searchTags"] = e.Fields["tags"].Replace(',', ' ');
	}
}
```

As long as the field is explicitly named "tags" (lowercase), all is good.  However I experienced a scenario where a field was renamed to "Tags" (title-case), and my code didn't run.

Making the dictionary key lookup to be case-insensitive will handle this scenario.

> Just for reference this happened with Umbraco - a developer created a doc-type containing a property-alias called "Tags".  I'm not sure how or why Umbraco let the title-cased alias through, but it happened. :confused:
> This led to Examine getting a distinct list of all user-fields (from the database) where "Tags" was used instead of lowercase "tags".

For the `StringComparer`, I went with Ordinal (instead of InvariantCulture) as per [MSDN's Recommendations for String Usage in .NET](https://msdn.microsoft.com/en-us/library/dd465121.aspx#recommendations_for_string_usage).