### PR TITLE
Allow runtime writing of IndexSets

### DIFF
--- a/Projects/Examine/LuceneEngine/Config/IndexSet.cs
+++ b/Projects/Examine/LuceneEngine/Config/IndexSet.cs
@@ -15,6 +15,10 @@ namespace Examine.LuceneEngine.Config
             {
                 return (string)this["SetName"];
             }
+            set
+            {
+                this["SetName"] = value;
+            }
         }
 
         private string m_IndexPath = "";
@@ -38,6 +42,7 @@ namespace Examine.LuceneEngine.Config
             }
             set
             {
+                this["IndexPath"] = value;
                 m_IndexPath = value;
             }
         }

--- a/Projects/Examine/LuceneEngine/Config/IndexSetCollection.cs
+++ b/Projects/Examine/LuceneEngine/Config/IndexSetCollection.cs
@@ -44,6 +44,11 @@ namespace Examine.LuceneEngine.Config
             {
                 return (IndexSet)this.BaseGet(setName);
             }
+            set
+            {
+                LockItem = false;
+                this.BaseAdd(value);
+            }
         }
     }
 }


### PR DESCRIPTION
Just came across a situation in a new e-Commerce platform that I am building, that requires dynamic runtime addition of new indexers for each category of product added.

And this pull request is basically a question whether its a good practice to allow IndexSets to be added in runtime. And curious to know why was it not considered in the original Examine.
