### PR TITLE
make topdocs public useful for fasctvector hight

### DIFF
--- a/Projects/Examine/LuceneEngine/SearchResults.cs
+++ b/Projects/Examine/LuceneEngine/SearchResults.cs
@@ -49,10 +49,16 @@ namespace Examine.LuceneEngine
 			private set;
 	    }
 
-        [SecuritySafeCritical]
-        private TopDocs _topDocs;
+        
+        public TopDocs TopDocs
+        {
+            [SecuritySafeCritical]
+            get;
+            [SecuritySafeCritical]
+            private set;
+        }
 
-		[SecuritySafeCritical]
+        [SecuritySafeCritical]
         internal SearchResults(Query query, IEnumerable<SortField> sortField, Searcher searcher)
         {
             LuceneQuery = query;
@@ -111,11 +117,11 @@ namespace Examine.LuceneEngine
 
             LuceneSearcher.Search(query, topDocsCollector);
 
-            _topDocs = sortField.Any()
+            TopDocs = sortField.Any()
                 ? ((TopFieldCollector)topDocsCollector).TopDocs()
                 : ((TopScoreDocCollector)topDocsCollector).TopDocs();
 
-            TotalItemCount = _topDocs.TotalHits;
+            TotalItemCount = TopDocs.TotalHits;
 
         }
 
@@ -181,9 +187,9 @@ namespace Examine.LuceneEngine
 		[SecuritySafeCritical]
 		private SearchResult CreateFromDocumentItem(int i)
 		{
-            var docId = _topDocs.ScoreDocs[i].doc;
+            var docId = TopDocs.ScoreDocs[i].doc;
             var doc = LuceneSearcher.Doc(docId);
-            var score = _topDocs.ScoreDocs[i].score;
+            var score = TopDocs.ScoreDocs[i].score;
             var result = CreateSearchResult(doc, score);
             return result;
         }
@@ -192,7 +198,7 @@ namespace Examine.LuceneEngine
         [SecuritySafeCritical]
 	    private int GetScoreDocsLength()
 	    {
-            var length = _topDocs.ScoreDocs.Length;
+            var length = TopDocs.ScoreDocs.Length;
 	        return length;
 	    }
 


### PR DESCRIPTION
In lucene.net contrib there is highlighter.net which I have working. However there is faster FastVectorHighlighter some sample code below on how to use

FastVectorHighlighter fvHighlighter = new FastVectorHighlighter(true,
true);
for (int i = 0; i < hits.ScoreDocs.Length; i++)
{
string bestfragment
fvHighlighter.GetBestFragment(fvHighlighter.GetFieldQuery(query),indexSearch.getIndexReader(),
hits.ScoreDocs[i].doc, "text", 20);
MessageBox.Show(bestfragment);
}

You need the ScoreDocs array to loop through to get the fragment.  Everything else I need is exposed as public like the reader and query only thing missing is ScoreDocs.