### PR TITLE
Issue #93: Now possible to pass multiple aliases to NodeTypeAlias()

### DIFF
--- a/src/Examine/LuceneEngine/SearchCriteria/LuceneQuery.cs
+++ b/src/Examine/LuceneEngine/SearchCriteria/LuceneQuery.cs
@@ -294,6 +294,30 @@ namespace Examine.LuceneEngine.SearchCriteria
         }
 
         /// <summary>
+        /// Query on the NodeTypeAlias
+        /// </summary>
+        /// <param name="nodeTypeAliases">Multiple node type aliases</param>
+        /// <returns>A new <see cref="Examine.SearchCriteria.IBooleanOperation"/> with the clause appended</returns>
+        public IBooleanOperation NodeTypeAlias(IExamineValue[] nodeTypeAliases)
+        {
+            return this.search.NodeTypeAliasInternal(nodeTypeAliases, occurance);
+        }
+        
+        /// <summary>
+        /// Query on the NodeTypeAlias
+        /// </summary>
+        /// <param name="nodeTypeAliases">Multiple node type aliases</param>
+        /// <returns>A new <see cref="Examine.SearchCriteria.IBooleanOperation"/> with the clause appended</returns>
+        public IBooleanOperation NodeTypeAlias(string[] nodeTypeAliases)
+        {
+            return this.search.NodeTypeAliasInternal(nodeTypeAliases
+                    .Select(x => new ExamineValue(Examineness.Explicit, x))
+                    .Cast<IExamineValue>()
+                    .ToArray(),
+                occurance);
+        }
+
+        /// <summary>
         /// Query on the specified field
         /// </summary>
         /// <param name="fieldName">Name of the field.</param>

--- a/src/Examine/SearchCriteria/IQuery.cs
+++ b/src/Examine/SearchCriteria/IQuery.cs
@@ -44,6 +44,18 @@ namespace Examine.SearchCriteria
         /// <returns></returns>
         IBooleanOperation NodeTypeAlias(IExamineValue nodeTypeAlias);
         /// <summary>
+        /// Query on the NodeTypeAlias
+        /// </summary>
+        /// <param name="nodeTypeAliases">Multiple NodeTypeAliases.</param>
+        /// <returns></returns>
+        IBooleanOperation NodeTypeAlias(IExamineValue[] nodeTypeAliases);
+        /// <summary>
+        /// Query on the NodeTypeAlias
+        /// </summary>
+        /// <param name="nodeTypeAliases">Multiple NodeTypeAliases.</param>
+        /// <returns></returns>
+        IBooleanOperation NodeTypeAlias(string[] nodeTypeAliases);
+        /// <summary>
         /// Query on the Parent ID
         /// </summary>
         /// <param name="id">The id of the parent.</param>


### PR DESCRIPTION
Made it possible to pass arrays to NodeTypeAlias() instead of using groupOr, to avoid values being passed through query parser