### PR TITLE
Make possible to use not LuceneIndexes in Umbraco.

### DIFF
--- a/src/Examine.AzureSearch/AzureSearchIndex.cs
+++ b/src/Examine.AzureSearch/AzureSearchIndex.cs
@@ -362,8 +362,15 @@ namespace Examine.AzureSearch
                         string.Join(", ", e.IndexingResults.Where(r => !r.Succeeded).Select(r => r.Key)));
                 }
 
+                CommitCount = totalResults;
                 onComplete(new IndexOperationEventArgs(this, totalResults));
             }
+        }
+        public int CommitCount { get; protected internal set; }
+
+        public override int GetCommitCount()
+        {
+            return CommitCount;
         }
 
         protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds, Action<IndexOperationEventArgs> onComplete)
@@ -372,7 +379,7 @@ namespace Examine.AzureSearch
 
             //TODO: Check exception: https://docs.microsoft.com/en-us/azure/search/search-howto-dotnet-sdk
             var result = indexer.Documents.Index(IndexBatch.Delete(FormatFieldName(LuceneIndex.ItemIdFieldName), itemIds));
-            
+            CommitCount = result.Results.Count;
             onComplete(new IndexOperationEventArgs(this, result.Results.Count));
         }
 

--- a/src/Examine/IIndex.cs
+++ b/src/Examine/IIndex.cs
@@ -34,7 +34,8 @@ namespace Examine
         /// Creates a new index, any existing index will be deleted
         /// </summary>
         void CreateIndex();
-        
+
+        int GetCommitCount();
         /// <summary>
         /// Returns the field definitions for the index
         /// </summary>

--- a/src/Examine/LuceneEngine/Providers/LuceneIndex.cs
+++ b/src/Examine/LuceneEngine/Providers/LuceneIndex.cs
@@ -53,7 +53,8 @@ namespace Examine.LuceneEngine.Providers
 
             _directory = luceneDirectory;
             //initialize the field types
-            _fieldValueTypeCollection = new Lazy<FieldValueTypeCollection>(() => CreateFieldValueTypes(indexValueTypesFactory));
+            _fieldValueTypeCollection =
+                new Lazy<FieldValueTypeCollection>(() => CreateFieldValueTypes(indexValueTypesFactory));
             _searcher = new Lazy<LuceneSearcher>(CreateSearcher);
             WaitForIndexQueueOnShutdown = true;
         }
@@ -83,7 +84,8 @@ namespace Examine.LuceneEngine.Providers
             DefaultAnalyzer = writer.Analyzer;
 
             //initialize the field types
-            _fieldValueTypeCollection = new Lazy<FieldValueTypeCollection>(() => CreateFieldValueTypes(indexValueTypesFactory));
+            _fieldValueTypeCollection =
+                new Lazy<FieldValueTypeCollection>(() => CreateFieldValueTypes(indexValueTypesFactory));
             LuceneIndexFolder = null;
             _searcher = new Lazy<LuceneSearcher>(CreateSearcher);
             WaitForIndexQueueOnShutdown = true;
@@ -158,7 +160,8 @@ namespace Examine.LuceneEngine.Providers
         /// <remarks>
         /// Each item in the collection is a collection itself, this allows us to have lazy access to a collection as part of the queue if added in bulk
         /// </remarks>
-        private readonly BlockingCollection<IEnumerable<IndexOperation>> _indexQueue = new BlockingCollection<IEnumerable<IndexOperation>>();
+        private readonly BlockingCollection<IEnumerable<IndexOperation>> _indexQueue =
+            new BlockingCollection<IEnumerable<IndexOperation>>();
 
         /// <summary>
         /// The async task that runs during an async indexing operation
@@ -196,17 +199,23 @@ namespace Examine.LuceneEngine.Providers
         public Analyzer DefaultAnalyzer { get; }
 
         private PerFieldAnalyzerWrapper _fieldAnalyzer;
+
         public PerFieldAnalyzerWrapper FieldAnalyzer => _fieldAnalyzer
-            ?? (_fieldAnalyzer =
-                (DefaultAnalyzer is PerFieldAnalyzerWrapper pfa)
-                    ? pfa
-                    : new PerFieldAnalyzerWrapper(DefaultAnalyzer));
+                                                        ?? (_fieldAnalyzer =
+                                                            (DefaultAnalyzer is PerFieldAnalyzerWrapper pfa)
+                                                                ? pfa
+                                                                : new PerFieldAnalyzerWrapper(DefaultAnalyzer));
 
         /// <summary>
         /// Used to keep track of how many index commits have been performed.
         /// This is used to determine when index optimization needs to occur.
         /// </summary>
         public int CommitCount { get; protected internal set; }
+
+        public override int GetCommitCount()
+        {
+            return CommitCount;
+        }
 
         /// <summary>
         /// Indicates whether or this system will process the queue items asynchonously - used for testing
@@ -217,7 +226,7 @@ namespace Examine.LuceneEngine.Providers
         /// The folder that stores the Lucene Index files
         /// </summary>
         public DirectoryInfo LuceneIndexFolder { get; protected set; }
-        
+
         /// <summary>
         /// returns true if the indexer has been canceled (app is shutting down)
         /// </summary>
@@ -226,7 +235,7 @@ namespace Examine.LuceneEngine.Providers
         #endregion
 
         #region Events
-        
+
         /// <summary>
         /// Occurs when [document writing].
         /// </summary>
@@ -261,7 +270,8 @@ namespace Examine.LuceneEngine.Providers
             base.OnIndexingError(e);
 
 #if FULLDEBUG
-            Trace.TraceError("Indexing Error Occurred: " + (e.InnerException == null ? e.Message : e.Message + " -- " + e.InnerException));
+            Trace.TraceError("Indexing Error Occurred: " +
+                             (e.InnerException == null ? e.Message : e.Message + " -- " + e.InnerException));
 #endif
 
             if (!RunAsync)
@@ -271,7 +281,6 @@ namespace Examine.LuceneEngine.Providers
                     msg += ". ERROR: " + e.InnerException.Message;
                 throw new Exception(msg, e.InnerException);
             }
-
         }
 
         protected virtual void OnDocumentWriting(DocumentWritingEventArgs docArgs)
@@ -283,7 +292,8 @@ namespace Examine.LuceneEngine.Providers
 
         #region Provider implementation
 
-        protected override void PerformIndexItems(IEnumerable<ValueSet> values, Action<IndexOperationEventArgs> onComplete)
+        protected override void PerformIndexItems(IEnumerable<ValueSet> values,
+            Action<IndexOperationEventArgs> onComplete)
         {
             //need to lock, we don't want to issue any node writing if there's an index rebuild occuring
             Monitor.Enter(_writerLocker);
@@ -311,7 +321,7 @@ namespace Examine.LuceneEngine.Providers
                 Monitor.Exit(_writerLocker);
             }
         }
-        
+
         /// <summary>
         /// Creates a brand new index, this will override any existing index with an empty one
         /// </summary>
@@ -386,7 +396,8 @@ namespace Examine.LuceneEngine.Providers
                 else
                 {
                     // we cannot acquire the lock, this is because the main writer is being created, or the index is being created currently
-                    OnIndexingError(new IndexingErrorEventArgs(this, "Could not acquire lock in EnsureIndex so cannot create new index", null, null));
+                    OnIndexingError(new IndexingErrorEventArgs(this,
+                        "Could not acquire lock in EnsureIndex so cannot create new index", null, null));
                 }
             }
         }
@@ -404,6 +415,7 @@ namespace Examine.LuceneEngine.Providers
                     //unlock it!
                     IndexWriter.Unlock(dir);
                 }
+
                 //create the writer (this will overwrite old index files)
                 writer = new IndexWriter(dir, FieldAnalyzer, true, IndexWriter.MaxFieldLength.UNLIMITED);
             }
@@ -427,9 +439,11 @@ namespace Examine.LuceneEngine.Providers
         {
             if (_cancellationTokenSource.IsCancellationRequested)
             {
-                OnIndexingError(new IndexingErrorEventArgs(this, "Cannot create a new index, indexing cancellation has been requested", null, null));
+                OnIndexingError(new IndexingErrorEventArgs(this,
+                    "Cannot create a new index, indexing cancellation has been requested", null, null));
                 return;
             }
+
             EnsureIndex(true);
         }
 
@@ -442,13 +456,15 @@ namespace Examine.LuceneEngine.Providers
         /// </remarks>
         /// <param name="itemIds">ID of the node to delete</param>
         /// <param name="onComplete"></param>
-        protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds, Action<IndexOperationEventArgs> onComplete)
+        protected override void PerformDeleteFromIndex(IEnumerable<string> itemIds,
+            Action<IndexOperationEventArgs> onComplete)
         {
             Interlocked.Increment(ref _activeAddsOrDeletes);
 
             try
             {
-                QueueIndexOperation(itemIds.Select(x => new IndexOperation(new ValueSet(x), IndexOperationType.Delete)));
+                QueueIndexOperation(itemIds.Select(x =>
+                    new IndexOperation(new ValueSet(x), IndexOperationType.Delete)));
                 SafelyProcessQueueItems(onComplete);
             }
             finally
@@ -469,7 +485,9 @@ namespace Examine.LuceneEngine.Providers
         {
             if (_cancellationTokenSource.IsCancellationRequested)
             {
-                OnIndexingError(new IndexingErrorEventArgs(this, "Cannot optimize index, index cancellation has been requested", null, null), true);
+                OnIndexingError(
+                    new IndexingErrorEventArgs(this, "Cannot optimize index, index cancellation has been requested",
+                        null, null), true);
                 return;
             }
 
@@ -481,7 +499,9 @@ namespace Examine.LuceneEngine.Providers
                 //check if the index is ready to be written to.
                 if (!IndexReady())
                 {
-                    OnIndexingError(new IndexingErrorEventArgs(this, "Cannot optimize index, the index is currently locked", null, null), true);
+                    OnIndexingError(
+                        new IndexingErrorEventArgs(this, "Cannot optimize index, the index is currently locked", null,
+                            null), true);
                     return;
                 }
 
@@ -495,19 +515,17 @@ namespace Examine.LuceneEngine.Providers
             {
                 OnIndexingError(new IndexingErrorEventArgs(this, "Error optimizing Lucene index", null, ex));
             }
-
         }
 
         #region Protected
-
-        
 
         /// <summary>
         /// Creates the <see cref="FieldValueTypeCollection"/> for this index
         /// </summary>
         /// <param name="indexValueTypesFactory"></param>
         /// <returns></returns>
-        protected virtual FieldValueTypeCollection CreateFieldValueTypes(IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null)
+        protected virtual FieldValueTypeCollection CreateFieldValueTypes(
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null)
         {
             //copy to writable dictionary
             var defaults = new Dictionary<string, IFieldValueTypeFactory>();
@@ -515,6 +533,7 @@ namespace Examine.LuceneEngine.Providers
             {
                 defaults[defaultIndexValueType.Key] = defaultIndexValueType.Value;
             }
+
             //copy the factory over the defaults
             if (indexValueTypesFactory != null)
             {
@@ -541,7 +560,6 @@ namespace Examine.LuceneEngine.Providers
         /// Check if there is an index in the index folder
         /// </summary>
         /// <returns></returns>
-
         public override bool IndexExists()
         {
             return _writer != null || IndexExistsImpl();
@@ -575,6 +593,7 @@ namespace Examine.LuceneEngine.Providers
                 using (IndexReader.Open(GetLuceneDirectory(), true))
                 {
                 }
+
                 ex = null;
                 return true;
             }
@@ -593,7 +612,6 @@ namespace Examine.LuceneEngine.Providers
         /// <remarks>
         /// If the index does not exist, it will not store the value so subsequent calls to this will re-evaulate
         /// </remarks>
-
         private bool IndexExistsImpl()
         {
             //if it's been set and it's true, return true
@@ -607,7 +625,6 @@ namespace Examine.LuceneEngine.Providers
 
             return _exists.Value;
         }
-
 
 
         /// <summary>
@@ -647,7 +664,8 @@ namespace Examine.LuceneEngine.Providers
             }
         }
 
-        private static IEnumerable<KeyValuePair<string, List<object>>> CopyDictionary(IDictionary<string, List<object>> d)
+        private static IEnumerable<KeyValuePair<string, List<object>>> CopyDictionary(
+            IDictionary<string, List<object>> d)
         {
             var result = new KeyValuePair<string, List<object>>[d.Count];
             d.CopyTo(result, 0);
@@ -663,13 +681,18 @@ namespace Examine.LuceneEngine.Providers
         protected virtual void AddDocument(Document doc, ValueSet valueSet, IndexWriter writer)
         {
             //add node id
-            var nodeIdValueType = FieldValueTypeCollection.GetValueType(ItemIdFieldName, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.Raw));
+            var nodeIdValueType = FieldValueTypeCollection.GetValueType(ItemIdFieldName,
+                FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.Raw));
             nodeIdValueType.AddValue(doc, valueSet.Id);
             //add the category
-            var categoryValueType = FieldValueTypeCollection.GetValueType(CategoryFieldName, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.InvariantCultureIgnoreCase));
+            var categoryValueType = FieldValueTypeCollection.GetValueType(CategoryFieldName,
+                FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes
+                    .InvariantCultureIgnoreCase));
             categoryValueType.AddValue(doc, valueSet.Category);
             //add the item type
-            var indexTypeValueType = FieldValueTypeCollection.GetValueType(ItemTypeFieldName, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.InvariantCultureIgnoreCase));
+            var indexTypeValueType = FieldValueTypeCollection.GetValueType(ItemTypeFieldName,
+                FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes
+                    .InvariantCultureIgnoreCase));
             indexTypeValueType.AddValue(doc, valueSet.ItemType);
 
             //copy to a new dictionary, there has been cases of an exception "Collection was modified; enumeration operation may not execute."
@@ -680,9 +703,11 @@ namespace Examine.LuceneEngine.Providers
                 {
                     var valueType = FieldValueTypeCollection.GetValueType(
                         definedFieldDefinition.Name,
-                        FieldValueTypeCollection.ValueTypeFactories.TryGetFactory(definedFieldDefinition.Type, out var valTypeFactory)
+                        FieldValueTypeCollection.ValueTypeFactories.TryGetFactory(definedFieldDefinition.Type,
+                            out var valTypeFactory)
                             ? valTypeFactory
-                            : FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.FullText));
+                            : FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes
+                                .FullText));
 
                     foreach (var o in field.Value)
                     {
@@ -693,7 +718,9 @@ namespace Examine.LuceneEngine.Providers
                 {
                     //Check for the special field prefix, if this is the case it's indexed as an invariant culture value
 
-                    var valueType = FieldValueTypeCollection.GetValueType(field.Key, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.InvariantCultureIgnoreCase));
+                    var valueType = FieldValueTypeCollection.GetValueType(field.Key,
+                        FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes
+                            .InvariantCultureIgnoreCase));
                     foreach (var o in field.Value)
                     {
                         valueType.AddValue(doc, o);
@@ -702,9 +729,11 @@ namespace Examine.LuceneEngine.Providers
                 else
                 {
                     //try to find the field definition for this field, if nothing is found use the default
-                    var def = FieldDefinitionCollection.GetOrAdd(field.Key, s => new FieldDefinition(s, FieldDefinitionTypes.FullText));
+                    var def = FieldDefinitionCollection.GetOrAdd(field.Key,
+                        s => new FieldDefinition(s, FieldDefinitionTypes.FullText));
 
-                    var valueType = FieldValueTypeCollection.GetValueType(def.Name, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.FullText));
+                    var valueType = FieldValueTypeCollection.GetValueType(def.Name,
+                        FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.FullText));
                     foreach (var o in field.Value)
                     {
                         valueType.AddValue(doc, o);
@@ -758,7 +787,8 @@ namespace Examine.LuceneEngine.Providers
 
                                 //when the task is done call the complete callback
                                 //TODO: Do we need to do anything if the task is canceled?
-                                _asyncTask.ContinueWith(task => onComplete?.Invoke(new IndexOperationEventArgs(this, task.Result)));
+                                _asyncTask.ContinueWith(task =>
+                                    onComplete?.Invoke(new IndexOperationEventArgs(this, task.Result)));
                             }
                         }
                     }
@@ -769,10 +799,10 @@ namespace Examine.LuceneEngine.Providers
                     //when the task is done call the complete callback
                     //note: this adds the callback to the queue since this method can be called multiple times with different callbacks
                     // but there is only one queue processing all requests. this ensures that all callbacks passed are executed, not just the first.
-                    _asyncTask?.ContinueWith(task => onComplete?.Invoke(new IndexOperationEventArgs(this, task.Result)));
+                    _asyncTask?.ContinueWith(task =>
+                        onComplete?.Invoke(new IndexOperationEventArgs(this, task.Result)));
                 }
             }
-
         }
 
         /// <summary>
@@ -787,7 +817,6 @@ namespace Examine.LuceneEngine.Providers
                 {
                     if (!_isIndexing && !_cancellationTokenSource.IsCancellationRequested)
                     {
-
                         _isIndexing = true;
 
                         var totalProcessed = 0;
@@ -809,7 +838,6 @@ namespace Examine.LuceneEngine.Providers
             }
 
             return 0;
-
         }
 
         /// <summary>
@@ -847,7 +875,8 @@ namespace Examine.LuceneEngine.Providers
             //check if the index is ready to be written to.
             if (!IndexReady())
             {
-                OnIndexingError(new IndexingErrorEventArgs(this, "Cannot index queue items, the index is currently locked", null, null));
+                OnIndexingError(new IndexingErrorEventArgs(this,
+                    "Cannot index queue items, the index is currently locked", null, null));
                 return 0;
             }
 
@@ -868,9 +897,9 @@ namespace Examine.LuceneEngine.Providers
                     }
 
                     foreach (var batch in _indexQueue.GetConsumingEnumerable())
-                        foreach (var item in batch)
-                            if (ProcessQueueItem(item, writer))
-                                indexedNodes++;
+                    foreach (var item in batch)
+                        if (ProcessQueueItem(item, writer))
+                            indexedNodes++;
                 }
                 else
                 {
@@ -1030,7 +1059,7 @@ namespace Examine.LuceneEngine.Providers
             //don't queue if there's been a cancellation requested
             if (!_cancellationTokenSource.IsCancellationRequested && !_indexQueue.IsAddingCompleted)
             {
-                _indexQueue.Add(new[] { op });
+                _indexQueue.Add(new[] {op});
             }
             else
             {
@@ -1058,7 +1087,7 @@ namespace Examine.LuceneEngine.Providers
                         "App is shutting down so index batch operation is ignored", null, null));
             }
         }
-        
+
         private readonly Directory _directory;
 
         /// <summary>
@@ -1091,7 +1120,10 @@ namespace Examine.LuceneEngine.Providers
                 try
                 {
                     System.IO.Directory.CreateDirectory(LuceneIndexFolder.FullName);
-                    _logOutput = new FileStream(Path.Combine(LuceneIndexFolder.FullName, DateTime.UtcNow.ToString("yyyy-MM-dd") + ".log"), FileMode.Append);
+                    _logOutput =
+                        new FileStream(
+                            Path.Combine(LuceneIndexFolder.FullName, DateTime.UtcNow.ToString("yyyy-MM-dd") + ".log"),
+                            FileMode.Append);
                     var w = new StreamWriter(_logOutput);
                     writer.SetInfoStream(w);
                 }
@@ -1140,7 +1172,6 @@ namespace Examine.LuceneEngine.Providers
                 {
                     Monitor.Exit(_writerLocker);
                 }
-
             }
 
             return _writer;
@@ -1152,7 +1183,7 @@ namespace Examine.LuceneEngine.Providers
 
         private LuceneSearcher CreateSearcher()
         {
-            var possibleSuffixes = new[] { "Index", "Indexer" };
+            var possibleSuffixes = new[] {"Index", "Indexer"};
             var name = Name;
             foreach (var suffix in possibleSuffixes)
             {
@@ -1162,8 +1193,6 @@ namespace Examine.LuceneEngine.Providers
             }
 
             return new LuceneSearcher(name + "Searcher", GetIndexWriter(), FieldAnalyzer, FieldValueTypeCollection);
-
-
         }
 
 
@@ -1175,7 +1204,6 @@ namespace Examine.LuceneEngine.Providers
         /// <param name="performCommit"></param>
         private void ProcessDeleteQueueItem(IndexOperation op, IndexWriter iw, bool performCommit = true)
         {
-
             //if the id is empty then remove the whole type
             if (!string.IsNullOrEmpty(op.ValueSet.Id))
             {
@@ -1192,7 +1220,6 @@ namespace Examine.LuceneEngine.Providers
 
         private bool ProcessIndexQueueItem(IndexOperation op, IndexWriter writer)
         {
-            
             //raise the event and assign the value to the returned data from the event
             var indexingNodeDataArgs = new IndexingItemEventArgs(this, op.ValueSet);
             OnTransformingIndexValues(indexingNodeDataArgs);
@@ -1277,14 +1304,13 @@ namespace Examine.LuceneEngine.Providers
             /// <summary>
             /// Handles the disposal of resources. Derived from abstract class <see cref="DisposableObject"/> which handles common required locking logic.
             /// </summary>
-
             protected override void DisposeResources()
             {
-
                 if (_index.WaitForIndexQueueOnShutdown)
                 {
                     //if there are active adds, lets way/retry (5 seconds)
-                    RetryUntilSuccessOrTimeout(() => _index._activeAddsOrDeletes == 0, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+                    RetryUntilSuccessOrTimeout(() => _index._activeAddsOrDeletes == 0, TimeSpan.FromSeconds(5),
+                        TimeSpan.FromSeconds(1));
                 }
 
                 //cancel any operation currently in place
@@ -1308,7 +1334,8 @@ namespace Examine.LuceneEngine.Providers
                 //Don't close the writer until there are definitely no more writes
                 //NOTE: we are not taking into acccount the WaitForIndexQueueOnShutdown property here because we really want to make sure
                 //we are not terminating Lucene while it is actively writing to the index.
-                RetryUntilSuccessOrTimeout(() => _index._activeWrites == 0, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(1));
+                RetryUntilSuccessOrTimeout(() => _index._activeWrites == 0, TimeSpan.FromMinutes(1),
+                    TimeSpan.FromSeconds(1));
 
                 //close the committer, this will ensure a final commit is made if one has been queued
                 _index._committer.Dispose();
@@ -1322,18 +1349,22 @@ namespace Examine.LuceneEngine.Providers
 
             private static bool RetryUntilSuccessOrTimeout(Func<bool> task, TimeSpan timeout, TimeSpan pause)
             {
-
                 if (pause.TotalMilliseconds < 0)
                 {
                     throw new ArgumentException("pause must be >= 0 milliseconds");
                 }
+
                 var stopwatch = Stopwatch.StartNew();
                 do
                 {
-                    if (task()) { return true; }
-                    Thread.Sleep((int)pause.TotalMilliseconds);
-                }
-                while (stopwatch.Elapsed < timeout);
+                    if (task())
+                    {
+                        return true;
+                    }
+
+                    Thread.Sleep((int) pause.TotalMilliseconds);
+                } while (stopwatch.Elapsed < timeout);
+
                 return false;
             }
         }
@@ -1347,14 +1378,10 @@ namespace Examine.LuceneEngine.Providers
             {
                 _searcher.Value.Dispose();
             }
+
             _disposer.Dispose();
         }
 
         #endregion
-
-
     }
-
-    
 }
-

--- a/src/Examine/Providers/BaseIndexProvider.cs
+++ b/src/Examine/Providers/BaseIndexProvider.cs
@@ -101,6 +101,8 @@ namespace Examine.Providers
         /// <returns></returns>
         public abstract bool IndexExists();
 
+        public abstract int GetCommitCount();
+
         #endregion
 
         #region Events


### PR DESCRIPTION
Hi Shannon, 
As I am almost finished with my ElasticSearch provider I notice to make possible to override basic indexes in Umbraco, I was getting 500 errors, because it was impossible to cast my index to LuceneIndex, here are I am attaching my changes to Lucene and as soon they will be approved I will prepare PR for Umbraco. :) 
**Description of Changes:**
Make possible to use IIndex instead of Lucene index in ExamineManagementController, moving CommitCount to be abstract.
If you have any comments I happy to prepare additional changes. 
