### PR TITLE
Azure Directory - should have explicit interface implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ src/packages/*
 /src/.vs/*
 /src/Examine.Web.Demo/_bin_deployableAssemblies/*
 /src/Examine.Web.Demo/App_Data/*
+src/.idea

--- a/src/Examine.AzureDirectory/AzureDirectoryFactory.cs
+++ b/src/Examine.AzureDirectory/AzureDirectoryFactory.cs
@@ -10,7 +10,7 @@ namespace Examine.AzureDirectory
     /// <summary>
     /// The <see cref="IDirectoryFactory"/> for storing master index data in Blob storage for use on the server that can actively write to the index
     /// </summary>
-    public class AzureDirectoryFactory : SyncTempEnvDirectoryFactory
+    public class AzureDirectoryFactory : SyncTempEnvDirectoryFactory, IDirectoryFactory
     {
         private readonly bool _isReadOnly;
 
@@ -45,7 +45,7 @@ namespace Examine.AzureDirectory
         /// <returns>
         /// The <see cref="Lucene.Net.Store.Directory"/>.
         /// </returns>
-        public override Lucene.Net.Store.Directory CreateDirectory(DirectoryInfo luceneIndexFolder)
+        public  Lucene.Net.Store.Directory CreateDirectory(DirectoryInfo luceneIndexFolder)
         {
             var indexFolder = luceneIndexFolder;
             var tempFolder = GetLocalStorageDirectory(indexFolder);


### PR DESCRIPTION
Hi @Shazwazza,
I was trying to use Azure Directory but I notice if I am using that part of code:
```  var factoryType = ExamineTypeFinder.GetTypeByName(configuredDirectoryFactory);
                if (factoryType == null)
                    throw new NullReferenceException("No directory type found for value: " +
                                                     configuredDirectoryFactory);
                var directoryFactory = (IDirectoryFactory) Activator.CreateInstance(factoryType);
                return directoryFactory.CreateDirectory(dirInfo);
```
just for reference my TypeFinder:
```  public static class ExamineTypeFinder
    {
         public static Type GetTypeByName(string typeName)
                {
                    var type = BuildManager.GetType(typeName, false);
                    if (type != null) return type;
        
                    // TODO: This isn't very elegant, and will have issues since the AppDomain.CurrentDomain
                    // doesn't actualy load in all assemblies, only the types that have been referenced so far.
                    // However, in a web context, the BuildManager will have executed which will force all assemblies
                    // to be loaded so it's fine for now.
                    // It could be fairly easy to parse the typeName to get the assembly name and then do Assembly.Load and
                    // find the type from there.
        
                    //now try fall back procedures.
                    type = Type.GetType(typeName);
                    if (type != null) return type;
                    return AppDomain.CurrentDomain.GetAssemblies()
                        .Select(x => x.GetType(typeName))
                        .FirstOrDefault(x => x != null);
                }
    }
```
I was failing as instead of using AzureDirectoryFactory.CreateDirectory() it was using SyncTempEnvDirectoryFactory.CreateDirectory(), as I was debugging it was caused because of the cast to interface.