### PR TITLE
Make possible to use SimpleInjector with ExamineManager

### DIFF
--- a/src/Examine/ExamineManager.cs
+++ b/src/Examine/ExamineManager.cs
@@ -31,7 +31,7 @@ namespace Examine
             if (instance is ExamineManager e) HostingEnvironment.UnregisterObject(e);
         }
 
-        private ExamineManager()
+        public ExamineManager()
         {
             if (!_defaultRegisteration) return;
             AppDomain.CurrentDomain.DomainUnload += (sender, args) => Dispose();


### PR DESCRIPTION
Hi Shannon,
I would use ExamineManager with SimpleInjector but actually I noticed it has a private constructor. 
I change that to be public, but would ask if you had any reason to make that private?
