### PR TITLE
Abstract base class for Search Results

### DIFF
--- a/src/Examine/Examine.csproj
+++ b/src/Examine/Examine.csproj
@@ -149,6 +149,7 @@
     <Compile Include="EmptySearchResults.cs" />
     <Compile Include="ExamineExtensions.cs" />
     <Compile Include="LuceneEngine\LuceneExtensions.cs" />
+    <Compile Include="LuceneEngine\LuceneSearchResultsBase.cs" />
     <Compile Include="LuceneEngine\OpenReaderTracker.cs" />
     <Compile Include="LuceneEngine\Providers\BaseLuceneSearcher.cs" />
     <Compile Include="IndexOperation.cs" />

--- a/src/Examine/Examine.csproj
+++ b/src/Examine/Examine.csproj
@@ -202,6 +202,7 @@
     <Compile Include="SearchResult.cs" />
     <Compile Include="Providers\BaseIndexProvider.cs" />
     <Compile Include="Providers\BaseSearchProvider.cs" />
+    <Compile Include="SearchResultsBase.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="TypeHelper.cs" />
     <Compile Include="ValueSet.cs" />

--- a/src/Examine/LuceneEngine/LuceneSearchResults.cs
+++ b/src/Examine/LuceneEngine/LuceneSearchResults.cs
@@ -12,6 +12,15 @@ namespace Examine.LuceneEngine
     /// </summary>
     public class LuceneSearchResults : LuceneSearchResultsBase
     {
+        ///<summary>
+        /// Returns an empty search result
+        ///</summary>
+        [Obsolete("Use the Empty property on SearchResultsBase instead")]
+        public static ISearchResults Empty()
+        {
+            return EmptySearchResults.Instance;
+        }
+
         /// <summary>
         /// Exposes the internal Lucene searcher
         /// </summary>
@@ -124,7 +133,7 @@ namespace Examine.LuceneEngine
             private readonly IEnumerator<ISearchResult> _baseEnumerator;
             private readonly IndexSearcher _searcher;
 
-            
+
             public DecrementReaderResult(IEnumerator<ISearchResult> baseEnumerator, Searcher searcher)
             {
                 _baseEnumerator = baseEnumerator;
@@ -133,7 +142,7 @@ namespace Examine.LuceneEngine
                 _searcher?.IndexReader.IncRef();
             }
 
-            
+
             public void Dispose()
             {
                 _baseEnumerator.Dispose();

--- a/src/Examine/LuceneEngine/LuceneSearchResults.cs
+++ b/src/Examine/LuceneEngine/LuceneSearchResults.cs
@@ -2,8 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Examine.LuceneEngine.Providers;
-using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 
@@ -12,7 +10,7 @@ namespace Examine.LuceneEngine
     /// <summary>
     /// An implementation of the search results returned from Lucene.Net
     /// </summary>
-    public class LuceneSearchResults : SearchResultsBase
+    public class LuceneSearchResults : LuceneSearchResultsBase
     {
         /// <summary>
         /// Exposes the internal Lucene searcher
@@ -85,60 +83,6 @@ namespace Examine.LuceneEngine
                 : ((TopScoreDocCollector)topDocsCollector).TopDocs();
 
             TotalItemCount = TopDocs.TotalHits;
-        }
-
-        /// <summary>
-        /// Internal cache of search results
-        /// </summary>
-        protected Dictionary<int, SearchResult> Docs = new Dictionary<int, SearchResult>();
-
-        /// <summary>
-        /// Creates the search result from a <see cref="Lucene.Net.Documents.Document"/>
-        /// </summary>
-        /// <param name="doc">The doc to convert.</param>
-        /// <param name="score">The score.</param>
-        /// <returns>A populated search result object</returns>
-        protected SearchResult CreateSearchResult(Document doc, float score)
-        {
-            var id = doc.Get("id");
-
-            if (string.IsNullOrEmpty(id) == true)
-            {
-                id = doc.Get(LuceneIndex.ItemIdFieldName);
-            }
-
-            var searchResult = new SearchResult(id, score, () =>
-            {
-                //we can use lucene to find out the fields which have been stored for this particular document
-                var fields = doc.GetFields();
-
-                var resultVals = new Dictionary<string, List<string>>();
-
-                foreach (var field in fields.Cast<Field>())
-                {
-                    var fieldName = field.Name;
-                    var values = doc.GetValues(fieldName);
-
-                    if (resultVals.TryGetValue(fieldName, out var resultFieldVals))
-                    {
-                        foreach (var value in values)
-                        {
-                            if (!resultFieldVals.Contains(value))
-                            {
-                                resultFieldVals.Add(value);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        resultVals[fieldName] = values.ToList();
-                    }
-                }
-
-                return resultVals;
-            });
-            
-            return searchResult;
         }
 
         //NOTE: If we moved this logic inside of the 'Skip' method like it used to be then we get the Code Analysis barking

--- a/src/Examine/LuceneEngine/LuceneSearchResultsBase.cs
+++ b/src/Examine/LuceneEngine/LuceneSearchResultsBase.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Examine.LuceneEngine.Providers;
+using Lucene.Net.Documents;
+
+namespace Examine.LuceneEngine
+{
+    public abstract class LuceneSearchResultsBase : SearchResultsBase
+    {
+        /// <summary>
+        /// Creates the search result from a <see cref="Lucene.Net.Documents.Document"/>
+        /// </summary>
+        /// <param name="doc">The doc to convert.</param>
+        /// <param name="score">The score.</param>
+        /// <returns>A populated search result object</returns>
+        protected virtual ISearchResult CreateSearchResult(Document doc, float score)
+        {
+            var id = doc.Get("id");
+
+            if (string.IsNullOrEmpty(id) == true)
+            {
+                id = doc.Get(LuceneIndex.ItemIdFieldName);
+            }
+
+            var searchResult = new SearchResult(id, score, () =>
+            {
+                //we can use lucene to find out the fields which have been stored for this particular document
+                var fields = doc.GetFields();
+
+                var resultVals = new Dictionary<string, List<string>>();
+
+                foreach (var field in fields.Cast<Field>())
+                {
+                    var fieldName = field.Name;
+                    var values = doc.GetValues(fieldName);
+
+                    if (resultVals.TryGetValue(fieldName, out var resultFieldVals))
+                    {
+                        foreach (var value in values)
+                        {
+                            if (!resultFieldVals.Contains(value))
+                            {
+                                resultFieldVals.Add(value);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        resultVals[fieldName] = values.ToList();
+                    }
+                }
+
+                return resultVals;
+            });
+
+            return searchResult;
+        }
+    }
+}

--- a/src/Examine/SearchResultsBase.cs
+++ b/src/Examine/SearchResultsBase.cs
@@ -33,7 +33,6 @@ namespace Examine
         /// <summary>
         /// Gets the total number of documents while enumerating results
         /// </summary>
-        //NOTE: This is totally retarded but it is required for medium trust as I cannot put this code inside the Skip method... wtf
         protected abstract int GetTotalDocs();
 
         /// <summary>

--- a/src/Examine/SearchResultsBase.cs
+++ b/src/Examine/SearchResultsBase.cs
@@ -22,7 +22,7 @@ namespace Examine
         /// <summary>
         /// Results for the search
         /// </summary>
-        public IDictionary<int, ISearchResult> Results { get; }
+        protected IDictionary<int, ISearchResult> Results { get; }
 
         /// <summary>
         /// Gets the total number of results for the search

--- a/src/Examine/SearchResultsBase.cs
+++ b/src/Examine/SearchResultsBase.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Examine
+{
+    public abstract class SearchResultsBase : ISearchResults
+    {
+        public SearchResultsBase()
+        {
+            Results = new Dictionary<int, ISearchResult>();
+        }
+
+        ///<summary>
+        /// Returns an empty search result
+        ///</summary>
+        ///<returns></returns>
+        public static ISearchResults Empty()
+        {
+            return EmptySearchResults.Instance;
+        }
+
+        /// <summary>
+        /// Results for the search
+        /// </summary>
+        public IDictionary<int, ISearchResult> Results { get; }
+
+        /// <summary>
+        /// Gets the total number of results for the search
+        /// </summary>
+        /// <value>The total items from the search.</value>
+        public long TotalItemCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the total number of documents while enumerating results
+        /// </summary>
+        //NOTE: This is totally retarded but it is required for medium trust as I cannot put this code inside the Skip method... wtf
+        protected abstract int GetTotalDocs();
+
+        /// <summary>
+        /// Gets a result at a given index while enumerating results
+        /// </summary>
+        protected abstract ISearchResult GetSearchResult(int index);
+
+        /// <summary>
+        /// Skips to a particular point in the search results.
+        /// </summary>
+        /// <remarks>
+        /// This allows for lazy loading of the results paging. We don't go into Lucene until we have to.
+        /// </remarks>
+        /// <param name="skip">The number of items in the results to skip.</param>
+        /// <returns>A collection of the search results</returns>
+        public virtual IEnumerable<ISearchResult> Skip(int skip)
+        {
+            for (int i = skip, x = GetTotalDocs(); i < x; i++)
+            {
+                if (Results.TryGetValue(i, out ISearchResult result) == false)
+                {
+                    result = GetSearchResult(i);
+
+                    if (result == null)
+                    {
+                        continue;
+                    }
+
+                    Results.Add(i, result);
+                }
+
+                //using yield return means if the user breaks out we wont keep going
+                //only load what we need to load!
+                //and we'll get it from our cache, this means you can go
+                //forward/ backwards without degrading performance
+                yield return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets the enumerator starting at position 0
+        /// </summary>
+        /// <returns>A collection of the search results</returns>
+        public virtual IEnumerator<ISearchResult> GetEnumerator()
+        {
+            return Skip(0).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
+        /// </returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
One thing I found painful when building [Examine Facets](https://github.com/callumbwhyte/examine-facets) was implementing the `ISearchResults` interface.

The `LuceneSearchResults` class contains a lot of complex logic for paging and building results from a `Document`. However it only has an internal constructor so it can't be easily reused. This is probably fine as in most cases you won't want all the search logic, but the paging is likely going to be needed in almost all implementations.

I created by own [abstract search results class](https://github.com/callumbwhyte/examine-facets/blob/dev/src/Examine.Facets/Search/FacetSearchResultsBase.cs) for facets but again it would cool if a lot of this could be re-used from Examine directly.

This PR standardises some of the helpful paging logic in `LuceneSearchResults` and moves it into 2 separate base classes: one provider agnostic, and one for the Lucene specific Document => ISearchResult logic.

Not sure what your thoughts are on this kind of change, so happy for discussion and feedback!