### PR TITLE
Fix possible memory leak in OrderedDictionary

### DIFF
--- a/src/Examine/OrderedDictionary.cs
+++ b/src/Examine/OrderedDictionary.cs
@@ -100,11 +100,8 @@ namespace Examine
             }
         }
 
-        private static readonly ICollection<TKey> EmptyCollection = new List<TKey>();
-        private static readonly ICollection<TVal> EmptyValues = new List<TVal>();
+        public ICollection<TKey> Keys => base.Dictionary != null ? base.Dictionary.Keys : new TKey[0];
 
-        public ICollection<TKey> Keys => base.Dictionary != null ? base.Dictionary.Keys : EmptyCollection;
-
-        public ICollection<TVal> Values => base.Dictionary != null ? base.Dictionary.Values.Select(x => x.Value).ToArray() : EmptyValues;
+        public ICollection<TVal> Values => base.Dictionary != null ? base.Dictionary.Values.Select(x => x.Value).ToArray() : new TVal[0];
     }
 }


### PR DESCRIPTION
I'm not 100% sure on this, but perhaps the static EmptyValues field is causing a memory leak. Either that or maybe the UmbracoExamineSearcher needs to be disposed.

Screenshot attached.

![image](https://user-images.githubusercontent.com/834725/90601523-7239bd80-e24c-11ea-97d9-15509e3aff01.png)
