### PR TITLE
remove deprecated Microsoft.WindowsAzure.Storage.Blob package

### DIFF
--- a/src/Examine.AzureDirectory/AzureDirectory.cs
+++ b/src/Examine.AzureDirectory/AzureDirectory.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using Examine.LuceneEngine.Directories;
 using Lucene.Net.Index;
 using Lucene.Net.Store;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
 
 namespace Examine.AzureDirectory
 {

--- a/src/Examine.AzureDirectory/AzureDirectoryFactory.cs
+++ b/src/Examine.AzureDirectory/AzureDirectoryFactory.cs
@@ -3,7 +3,7 @@ using System.IO;
 using Examine.LuceneEngine.Directories;
 using Examine.LuceneEngine.Providers;
 using Lucene.Net.Store;
-using Microsoft.WindowsAzure.Storage;
+using Microsoft.Azure.Storage;
 
 namespace Examine.AzureDirectory
 {

--- a/src/Examine.AzureDirectory/AzureIndexInput.cs
+++ b/src/Examine.AzureDirectory/AzureIndexInput.cs
@@ -5,7 +5,7 @@ using System.IO.Compression;
 using System.Threading;
 using Examine.LuceneEngine.Directories;
 using Lucene.Net.Store;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
 
 namespace Examine.AzureDirectory
 {

--- a/src/Examine.AzureDirectory/AzureIndexOutput.cs
+++ b/src/Examine.AzureDirectory/AzureIndexOutput.cs
@@ -5,7 +5,7 @@ using System.IO.Compression;
 using System.Threading;
 using Examine.LuceneEngine.Directories;
 using Lucene.Net.Store;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
 
 namespace Examine.AzureDirectory
 {

--- a/src/Examine.AzureDirectory/Examine.AzureDirectory.csproj
+++ b/src/Examine.AzureDirectory/Examine.AzureDirectory.csproj
@@ -39,6 +39,12 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Blob">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.2.2\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Common">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.2.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
@@ -50,9 +56,6 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.1\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/Examine.AzureDirectory/packages.config
+++ b/src/Examine.AzureDirectory/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.Blob" version="11.2.2" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.Common" version="11.2.2" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />
@@ -13,5 +15,4 @@
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The original WindowsAzure.Storage package is now deprecated (https://github.com/Azure/azure-storage-net). This pull request migrates to the supported Microsoft.Azure.Storage package.