### PR TITLE
Prevent NotSupportedException being thrown for queries including TermRangeQuery, WildcardQuery and FuzzyQuery

### DIFF
--- a/src/Examine/LuceneEngine/Providers/BaseLuceneSearcher.cs
+++ b/src/Examine/LuceneEngine/Providers/BaseLuceneSearcher.cs
@@ -178,7 +178,7 @@ namespace Examine.LuceneEngine.Providers
             var searcher = GetSearcher();
             if (searcher == null) return new EmptySearchResults();
 
-            var pagesResults = new SearchResults(luceneParams.Query, luceneParams.SortFields, searcher, maxResults);
+            var pagesResults = new SearchResults(luceneParams.Query, luceneParams.SortFields, searcher, maxResults, luceneParams.ExtractTermsNotSupported);
             return pagesResults;
         }
 

--- a/src/Examine/LuceneEngine/SearchCriteria/LuceneSearchCriteria.cs
+++ b/src/Examine/LuceneEngine/SearchCriteria/LuceneSearchCriteria.cs
@@ -24,6 +24,7 @@ namespace Examine.LuceneEngine.SearchCriteria
     public class LuceneSearchCriteria : ISearchCriteria
     {
         internal static Regex SortMatchExpression = new Regex(@"(\[Type=(?<type>\w+?)\])", RegexOptions.Compiled);
+        internal bool ExtractTermsNotSupported = false;
 
         public MultiFieldQueryParser QueryParser
         {
@@ -356,6 +357,10 @@ namespace Examine.LuceneEngine.SearchCriteria
                     }
                     break;
             }
+            if(queryToAdd is TermRangeQuery || queryToAdd is WildcardQuery || queryToAdd is FuzzyQuery)
+            {
+                ExtractTermsNotSupported = true; //ExtractTerms() not supported by TermRangeQuery, WildcardQuery,FuzzyQuery and will throw NotSupportedException 
+            }
             return queryToAdd;
         }
 
@@ -559,7 +564,7 @@ namespace Examine.LuceneEngine.SearchCriteria
         protected internal IBooleanOperation RangeInternal(string fieldName, string start, string end, bool includeLower, bool includeUpper, BooleanClause.Occur occurance)
         {
             Query.Add(new TermRangeQuery(fieldName, start, end, includeLower, includeUpper), occurance);
-
+            ExtractTermsNotSupported = true; //ExtractTerms() not supported by TermRangeQuery and will throw NotSupportedException 
             return new LuceneBooleanOperation(this);
         }
 
@@ -824,7 +829,13 @@ namespace Examine.LuceneEngine.SearchCriteria
 		[SecuritySafeCritical]
 		public ISearchCriteria RawQuery(string query)
         {
-            this.Query.Add(this.QueryParser.Parse(query), this._occurance);            
+            var parsedQuery = QueryParser.Parse(query);
+            this.Query.Add(parsedQuery, this._occurance);
+            if (parsedQuery is TermRangeQuery || parsedQuery is WildcardQuery || parsedQuery is FuzzyQuery)
+            {
+                ExtractTermsNotSupported = true; //ExtractTerms() not supported by TermRangeQuery, WildcardQuery,FuzzyQuery and will throw NotSupportedException 
+            }
+
             return this;
         }
 


### PR DESCRIPTION
Prevent NotSupportedException being thrown when calling ExtractTerms when a query includes a TermRangeQuery, WildcardQuery or FuzzyQuery as these types of queries throw NotSupportedException for their implementation of ExtractTerms.