### PR TITLE
Escape simple/complex wildcard value

### DIFF
--- a/src/Examine/LuceneEngine/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine/LuceneEngine/Search/LuceneSearchQueryBase.cs
@@ -317,7 +317,7 @@ namespace Examine.LuceneEngine.Search
                 case Examineness.SimpleWildcard:
                 case Examineness.ComplexWildcard:
 
-                    var searchValue = fieldValue.Value + (fieldValue.Examineness == Examineness.ComplexWildcard ? "*" : "?");
+                    var searchValue = QueryParser.Escape(fieldValue.Value) + (fieldValue.Examineness == Examineness.ComplexWildcard ? "*" : "?");
 
                     if (useQueryParser)
                     {


### PR DESCRIPTION
This fixes https://github.com/Shazwazza/Examine/issues/187 by always escaping the value for `SimpleWildcard` and `ComplexWildcard` Examine values.