### PR TITLE
Allow implementing WriterFactory in LuceneIndex

### DIFF
--- a/src/Examine/LuceneEngine/Providers/LuceneIndex.cs
+++ b/src/Examine/LuceneEngine/Providers/LuceneIndex.cs
@@ -1209,7 +1209,7 @@ namespace Examine.LuceneEngine.Providers
         /// </summary>
         /// <param name="d"></param>
         /// <returns></returns>
-        private IndexWriter WriterFactory(Directory d)
+        protected virtual IndexWriter WriterFactory(Directory d)
         {
             if (d == null) throw new ArgumentNullException(nameof(d));
             var writer = new IndexWriter(d, FieldAnalyzer, false, IndexWriter.MaxFieldLength.UNLIMITED);


### PR DESCRIPTION
What?
Allow for replacing the writerfactory method in LuceneIndex.
Why?
Allows for changing the Merge Policy and DeletionPolicy when using a remote directory.