### PR TITLE
Handle queryparser returning null for boosted fields

### DIFF
--- a/src/Examine/LuceneEngine/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine/LuceneEngine/Search/LuceneSearchQueryBase.cs
@@ -335,7 +335,10 @@ namespace Examine.LuceneEngine.Search
                     if (useQueryParser)
                     {
                         queryToAdd = _queryParser.GetFieldQueryInternal(fieldName, fieldValue.Value);
-                        queryToAdd.Boost = fieldValue.Level;
+                        if (queryToAdd != null)
+                        { 
+                            queryToAdd.Boost = fieldValue.Level;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
I have no idea how to provoke this with a unit-test, but when using `GroupedOr` on all search fields, with `new ExamineValue(Examineness.Boosted, x, 1.5f)`, my queries blow up with a nullref exception in `GetFieldInternalQuery`.  
It blows up on the built-in field "icon" with the phrase "this".  
I'm sure it's a default stop word and lucene throws it out, but it should be up to Examine to handle that null.  
I've tested this fix manually and it does indeed cure our site. 😇