### PR TITLE
Fix paging when Skip == 1

### DIFF
--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -76,7 +76,7 @@ namespace Examine.Lucene.Search
                 }
             }
 
-            var maxResults = Math.Min((_options.Skip == 0 ? 1 : _options.Skip) * _options.Take, MaxDoc);
+            var maxResults = Math.Min((_options.Skip + 1) * _options.Take, MaxDoc);
             maxResults = maxResults >= 1 ? maxResults : QueryOptions.DefaultMaxResults;
 
             ICollector topDocsCollector;

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -2427,5 +2427,45 @@ namespace Examine.Test.Examine.Lucene.Search
                 Assert.AreEqual(0, results.Count);
             }
         }
+
+        [TestCase(0, 1, 1)]
+        [TestCase(0, 2, 2)]
+        [TestCase(0, 3, 3)]
+        [TestCase(0, 4, 4)]
+        [TestCase(0, 5, 5)]
+        [TestCase(0, 100, 5)]
+        [TestCase(1, 1, 1)]
+        [TestCase(1, 2, 2)]
+        [TestCase(1, 3, 3)]
+        [TestCase(1, 4, 4)]
+        [TestCase(1, 5, 4)]
+        [TestCase(2, 2, 2)]
+        [TestCase(2, 5, 3)]
+        public void Given_SkipTake_Returns_ExpectedTotals(int skip, int take, int expectedResults)
+        {
+            const int indexSize = 5;
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(luceneDir, analyzer))
+            {
+                var items = Enumerable.Range(0, indexSize).Select(x => ValueSet.FromObject(x.ToString(), "content",
+                    new { nodeName = "umbraco", headerText = "world", writerName = "administrator" }));
+
+                indexer.IndexItems(items);
+
+                var searcher = indexer.Searcher;
+
+                //Arrange
+
+                var sc = searcher.CreateQuery("content").Field("writerName", "administrator");
+
+                //Act
+
+                var results = sc.Execute(QueryOptions.SkipTake(skip, take));
+
+                Assert.AreEqual(indexSize, results.TotalItemCount);
+                Assert.AreEqual(expectedResults, results.Count());
+            }
+        }
     }
 }


### PR DESCRIPTION
When Skip == 1, the Take value would be one less than expected.
I've added tests to verify, and all existing tests pass

Fixes https://github.com/umbraco/Umbraco-CMS/issues/11377