### PR TITLE
Set Lucene search options on the parser

### DIFF
--- a/src/Examine.Lucene/Search/LuceneSearchOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchOptions.cs
@@ -1,10 +1,80 @@
-﻿namespace Examine.Lucene.Search
+using System;
+using System.Globalization;
+using Lucene.Net.Documents;
+using Lucene.Net.Search;
+
+namespace Examine.Lucene.Search
 {
     /// <summary>
     /// Options to configure <see cref="LuceneSearchQuery"/>
     /// </summary>
     public class LuceneSearchOptions
     {
-        public bool AllowLeadingWildcard { get; set; }
+        //
+        // Summary:
+        //     Whether terms of multi-term queries (e.g., wildcard, prefix, fuzzy and range)
+        //     should be automatically lower-cased or not. Default is true.
+        public bool? LowercaseExpandedTerms { get; set; }
+
+        //
+        // Summary:
+        //     Set to true to allow leading wildcard characters.
+        //     When set, * or ? are allowed as the first character of a Lucene.Net.Search.PrefixQuery
+        //     and Lucene.Net.Search.WildcardQuery. Note that this can produce very slow queries
+        //     on big indexes.
+        //     Default: false.
+        public bool? AllowLeadingWildcard { get; set; }
+
+        //
+        // Summary:
+        //     Set to true to enable position increments in result query.
+        //     When set, result phrase and multi-phrase queries will be aware of position increments.
+        //     Useful when e.g. a Lucene.Net.Analysis.Core.StopFilter increases the position
+        //     increment of the token that follows an omitted token.
+        //     Default: false.
+        public bool? EnablePositionIncrements { get; set; }
+
+        //
+        // Summary:
+        //     By default, it uses Lucene.Net.Search.MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT
+        //     when creating a prefix, wildcard and range queries. This implementation is generally
+        //     preferable because it a) Runs faster b) Does not have the scarcity of terms unduly
+        //     influence score c) avoids any exception due to too many listeners. However, if
+        //     your application really needs to use the old-fashioned boolean queries expansion
+        //     rewriting and the above points are not relevant then use this change the rewrite
+        //     method.
+        public MultiTermQuery.RewriteMethod MultiTermRewriteMethod { get; set; }
+
+        //
+        // Summary:
+        //     Get or Set the prefix length for fuzzy queries. Default is 0.
+        public int? FuzzyPrefixLength { get; set; }
+
+        //
+        // Summary:
+        //     Get or Set locale used by date range parsing.
+        public CultureInfo Locale { get; set; }
+
+        //
+        // Summary:
+        //     Gets or Sets the time zone.
+        public TimeZoneInfo TimeZone { get; set; }
+
+        //
+        // Summary:
+        //     Gets or Sets the default slop for phrases. If zero, then exact phrase matches
+        //     are required. Default value is zero.
+        public int? PhraseSlop { get; set; }
+
+        //
+        // Summary:
+        //     Get the minimal similarity for fuzzy queries.
+        public float? FuzzyMinSim { get; set; }
+
+        //
+        // Summary:
+        //     Sets the default Lucene.Net.Documents.DateTools.Resolution used for certain field
+        //     when no Lucene.Net.Documents.DateTools.Resolution is defined for this field.
+        public DateTools.Resolution? DateResolution { get; set; }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -21,13 +21,61 @@ namespace Examine.Lucene.Search
         public LuceneSearchQuery(
             ISearchContext searchContext,
             string category, Analyzer analyzer, LuceneSearchOptions searchOptions, BooleanOperation occurance)
-            : base(CreateQueryParser(searchContext, analyzer), category, searchOptions, occurance)
+            : base(CreateQueryParser(searchContext, analyzer, searchOptions), category, searchOptions, occurance)
         {   
             _searchContext = searchContext;
         }
 
-        private static CustomMultiFieldQueryParser CreateQueryParser(ISearchContext searchContext, Analyzer analyzer)
-            => new ExamineMultiFieldQueryParser(searchContext, LuceneInfo.CurrentVersion, analyzer);
+        private static CustomMultiFieldQueryParser CreateQueryParser(ISearchContext searchContext, Analyzer analyzer, LuceneSearchOptions searchOptions)
+        {
+            var parser = new ExamineMultiFieldQueryParser(searchContext, LuceneInfo.CurrentVersion, analyzer);
+
+            if (searchOptions != null)
+            {
+                if (searchOptions.LowercaseExpandedTerms.HasValue)
+                {
+                    parser.LowercaseExpandedTerms = searchOptions.LowercaseExpandedTerms.Value;
+                }
+                if (searchOptions.AllowLeadingWildcard.HasValue)
+                {
+                    parser.AllowLeadingWildcard = searchOptions.AllowLeadingWildcard.Value;
+                }
+                if (searchOptions.EnablePositionIncrements.HasValue)
+                {
+                    parser.EnablePositionIncrements = searchOptions.EnablePositionIncrements.Value;
+                }
+                if (searchOptions.MultiTermRewriteMethod != null)
+                {
+                    parser.MultiTermRewriteMethod = searchOptions.MultiTermRewriteMethod;
+                }
+                if (searchOptions.FuzzyPrefixLength.HasValue)
+                {
+                    parser.FuzzyPrefixLength = searchOptions.FuzzyPrefixLength.Value;
+                }
+                if (searchOptions.Locale != null)
+                {
+                    parser.Locale = searchOptions.Locale;
+                }
+                if (searchOptions.TimeZone != null)
+                {
+                    parser.TimeZone = searchOptions.TimeZone;
+                }
+                if (searchOptions.PhraseSlop.HasValue)
+                {
+                    parser.PhraseSlop = searchOptions.PhraseSlop.Value;
+                }
+                if (searchOptions.FuzzyMinSim.HasValue)
+                {
+                    parser.FuzzyMinSim = searchOptions.FuzzyMinSim.Value;
+                }
+                if (searchOptions.DateResolution.HasValue)
+                {
+                    parser.SetDateResolution(searchOptions.DateResolution.Value);
+                }
+            }
+
+            return parser;
+        }
 
         public virtual IBooleanOperation OrderBy(params SortableField[] fields) => OrderByInternal(false, fields);
 


### PR DESCRIPTION
@Shazwazza I saw the AllowLeadingWildcards option wasn't being used anymore, and I wasn't sure if that was intentional, or if that was just in the push to get everything up that got lost or didn't get into rev 1.  If it wasn't intentionally removed, I have this pull request that allows you to set it and the other options from the `Lucene.Net.QueryParsers.Flexible.Standard.ICommonQueryParserConfiguration` interface.  Since I wasn't sure if it was intentional, I didn't open an issue on it, but I can open an issue and link it to this if you'd like.