### PR TITLE
Improve logging performance.

### DIFF
--- a/src/Examine.Lucene/ExamineReplicator.cs
+++ b/src/Examine.Lucene/ExamineReplicator.cs
@@ -50,11 +50,14 @@ namespace Examine.Lucene
                             var destDir = destinationDirectory as FSDirectory;
 
                             // Callback, can be used to notifiy when replication is done (i.e. to open the index)
-                            _logger.LogDebug(
-                                "{IndexName} replication complete from {SourceDirectory} to {DestinationDirectory}",
-                                sourceIndex.Name,
-                                sourceDir?.Directory.ToString() ?? "InMemory",
-                                destDir?.Directory.ToString() ?? "InMemory");
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug(
+                                    "{IndexName} replication complete from {SourceDirectory} to {DestinationDirectory}",
+                                    sourceIndex.Name,
+                                    sourceDir?.Directory.ToString() ?? "InMemory",
+                                    destDir?.Directory.ToString() ?? "InMemory");
+                            }
                         }
                         // Doesn't matter what is returned, Lucene.Net doesn't use this value
                         return true;
@@ -120,7 +123,10 @@ namespace Examine.Lucene
         private void SourceIndex_IndexCommitted(object sender, EventArgs e)
         {
             var index = (LuceneIndex)sender;
-            _logger.LogDebug("{IndexName} committed", index.Name);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("{IndexName} committed", index.Name);
+            }
             var rev = new IndexRevision(_sourceIndex.IndexWriter.IndexWriter);
             _replicator.Publish(rev);
         }

--- a/src/Examine.Lucene/Indexing/IndexFieldValueTypeBase.cs
+++ b/src/Examine.Lucene/Indexing/IndexFieldValueTypeBase.cs
@@ -91,8 +91,10 @@ namespace Examine.Lucene.Indexing
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogDebug(ex, "An conversion error occurred with from inputConverter.ConvertTo {FromValue} to {ToValueType}", val, typeof(T));
-
+                    if (Logger.IsEnabled(LogLevel.Debug))
+                    {
+                        Logger.LogDebug(ex, "An conversion error occurred with from inputConverter.ConvertTo {FromValue} to {ToValueType}", val, typeof(T));
+                    }
                     parsedVal = default(T);
                     return false;
                 }
@@ -109,8 +111,10 @@ namespace Examine.Lucene.Indexing
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogDebug(ex, "An conversion error occurred with outputConverter.ConvertFrom from {FromValue} to {ToValueType}", val, typeof(T));
-
+                    if (Logger.IsEnabled(LogLevel.Debug))
+                    {
+                        Logger.LogDebug(ex, "An conversion error occurred with outputConverter.ConvertFrom from {FromValue} to {ToValueType}", val, typeof(T));
+                    }
                     parsedVal = default(T);
                     return false;
                 }
@@ -124,8 +128,10 @@ namespace Examine.Lucene.Indexing
             }
             catch (Exception ex)
             {
-                Logger.LogDebug(ex, "An conversion error occurred with Convert.ChangeType from {FromValue} to {ToValueType}", val, typeof(T));
-
+                if (Logger.IsEnabled(LogLevel.Debug))
+                {
+                    Logger.LogDebug(ex, "An conversion error occurred with Convert.ChangeType from {FromValue} to {ToValueType}", val, typeof(T));
+                }
                 parsedVal = default(T);
                 return false;
             }

--- a/src/Examine.Lucene/LoggingInfoStream.cs
+++ b/src/Examine.Lucene/LoggingInfoStream.cs
@@ -11,6 +11,11 @@ namespace Examine.Lucene
 
         public override bool IsEnabled(string component) => Logger.IsEnabled(LogLevel.Debug);
         public override void Message(string component, string message)
-            => Logger.LogDebug("{Component} - {Message}", component, message);
+        {
+            if (Logger.IsEnabled(LogLevel.Debug))
+            {
+                Logger.LogDebug("{Component} - {Message}", component, message);
+            }
+        }
     }
 }

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -320,7 +320,10 @@ namespace Examine.Lucene.Providers
 
                         if (!indexExists)
                         {
-                            _logger.LogDebug("Initializing new index {IndexName}", Name);
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug("Initializing new index {IndexName}", Name);
+                            }
 
                             //if there's no index, we need to create one
                             CreateNewIndex(dir);
@@ -328,8 +331,10 @@ namespace Examine.Lucene.Providers
                         else
                         {
                             //it does exists so we'll need to clear it out
-
-                            _logger.LogDebug("Clearing existing index {IndexName}", Name);
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug("Clearing existing index {IndexName}", Name);
+                            }
 
                             if (_writer == null)
                             {
@@ -686,11 +691,14 @@ namespace Examine.Lucene.Providers
         /// <param name="writer">The writer that will be used to update the Lucene index.</param>
         protected virtual void AddDocument(Document doc, ValueSet valueSet)
         {
-            _logger.LogDebug("{IndexName} Write lucene doc id:{DocumentId}, category:{DocumentCategory}, type:{DocumentItemType}",
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("{IndexName} Write lucene doc id:{DocumentId}, category:{DocumentCategory}, type:{DocumentItemType}",
                 Name,
                 valueSet.Id,
                 valueSet.Category,
                 valueSet.ItemType);
+            }
 
             //add node id
             IIndexFieldValueType nodeIdValueType = FieldValueTypeCollection.GetValueType(ExamineFieldNames.ItemIdFieldName, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.Raw));
@@ -912,8 +920,10 @@ namespace Examine.Lucene.Providers
             {
                 if (IsLocked(dir))
                 {
-                    _logger.LogDebug("Forcing index {IndexName} to be unlocked since it was left in a locked state", Name);
-
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Forcing index {IndexName} to be unlocked since it was left in a locked state", Name);
+                    }
                     //unlock it!
                     Unlock(dir);
                 }
@@ -1100,14 +1110,20 @@ namespace Examine.Lucene.Providers
                 {
                     if (_asyncTask.IsCanceled)
                     {
-                        _logger.LogDebug("{IndexName} Indexing cancellation requested, cannot proceed", Name);
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            _logger.LogDebug("{IndexName} Indexing cancellation requested, cannot proceed", Name);
+                        }
                         onComplete?.Invoke(new IndexOperationEventArgs(this, 0));
                     }
                     else
                     {
                         if (_asyncTask.IsCompleted)
                         {
-                            _logger.LogDebug("{IndexName} Queuing a new background thread", Name);
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug("{IndexName} Queuing a new background thread", Name);
+                            }
                         }
 
                         // The task is initialized to completed so just continue with
@@ -1140,12 +1156,18 @@ namespace Examine.Lucene.Providers
 
                         if (t.IsCanceled)
                         {
-                            _logger.LogDebug("{IndexName} Task was cancelled before it began", Name);
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug("{IndexName} Task was cancelled before it began", Name);
+                            }
                             onComplete?.Invoke(new IndexOperationEventArgs(this, 0));
                         }
                         else if (t.IsFaulted)
                         {
-                            _logger.LogDebug(_asyncTask.Exception, "{IndexName} Task was cancelled before it began", Name);
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                            {
+                                _logger.LogDebug(_asyncTask.Exception, "{IndexName} Task was cancelled before it began", Name);
+                            }
                             onComplete?.Invoke(new IndexOperationEventArgs(this, 0));
                         }
 
@@ -1170,7 +1192,10 @@ namespace Examine.Lucene.Providers
             if (_latestGen.HasValue && !_disposedValue && !_cancellationToken.IsCancellationRequested)
             {
                 var found = _nrtReopenThread?.WaitForGeneration(_latestGen.Value, 5000);
-                _logger.LogDebug("{IndexName} WaitForChanges returned {GenerationFound}", Name, found);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("{IndexName} WaitForChanges returned {GenerationFound}", Name, found);
+                }
             }
         }
 
@@ -1304,7 +1329,12 @@ namespace Examine.Lucene.Providers
         void ReferenceManager.IRefreshListener.BeforeRefresh() { }
 
         void ReferenceManager.IRefreshListener.AfterRefresh(bool didRefresh)
-            => _logger.LogDebug("{IndexName} searcher refreshed? {DidRefresh}", Name, didRefresh);
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("{IndexName} searcher refreshed? {DidRefresh}", Name, didRefresh);
+            }
+        }
     }
 
 


### PR DESCRIPTION
Avoid logging allocations when debug logging level is not enabled.
Checks if the debug log level is enabled before calling log debug methods. This saves on creating the params array, saving allocations, improving performance.