### PR TITLE
Make ValueSet mutable again and always create a copy of the values

### DIFF
--- a/src/Examine.Core/IndexingItemEventArgs.cs
+++ b/src/Examine.Core/IndexingItemEventArgs.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 
 namespace Examine
 {
@@ -18,11 +15,6 @@ namespace Examine
         public ValueSet ValueSet { get; }
 
         /// <summary>
-        /// Gets the transformed values to index.
-        /// </summary>
-        public IDictionary<string, IList<object>> TransformedValues { get; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="IndexingItemEventArgs" /> class.
         /// </summary>
         /// <param name="index">The index.</param>
@@ -31,7 +23,6 @@ namespace Examine
         {
             Index = index;
             ValueSet = valueSet;
-            TransformedValues = valueSet.Values.ToDictionary<KeyValuePair<string, IReadOnlyList<object>>, string, IList<object>>(x => x.Key, x => x.Value.ToList());
         }
     }
 }

--- a/src/Examine.Core/IndexingItemEventArgs.cs
+++ b/src/Examine.Core/IndexingItemEventArgs.cs
@@ -1,22 +1,55 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Examine
 {
     public class IndexingItemEventArgs : CancelEventArgs
     {
+        /// <summary>
+        /// Gets the index.
+        /// </summary>
         public IIndex Index { get; }
 
-        public ValueSet ValueSet { get; private set; }
+        /// <summary>
+        /// Gets the value set.
+        /// </summary>
+        public ValueSet ValueSet { get; }
 
+        /// <summary>
+        /// Gets the transformed values to index.
+        /// </summary>
+        public IDictionary<string, IList<object>> TransformedValues { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndexingItemEventArgs" /> class.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        /// <param name="valueSet">The value set.</param>
         public IndexingItemEventArgs(IIndex index, ValueSet valueSet)
         {
             Index = index;
             ValueSet = valueSet;
+            TransformedValues = valueSet.Values.ToDictionary<KeyValuePair<string, IReadOnlyList<object>>, string, IList<object>>(x => x.Key, x => x.Value.ToList());
         }
 
+        /// <summary>
+        /// Sets the values.
+        /// </summary>
+        /// <param name="values">The values.</param>
+        [Obsolete("Set the values on the TransformedValues property instead to prevent unnecessary allocations.")]
         public void SetValues(IDictionary<string, IEnumerable<object>> values)
-            => ValueSet = new ValueSet(ValueSet.Id, ValueSet.Category, ValueSet.ItemType, values);
+        {
+            TransformedValues.Clear();
+
+            if (values != null)
+            {
+                foreach (KeyValuePair<string, IEnumerable<object>> value in values)
+                {
+                    TransformedValues.Add(value.Key, value.Value.ToList());
+                }
+            }
+        }
     }
 }

--- a/src/Examine.Core/IndexingItemEventArgs.cs
+++ b/src/Examine.Core/IndexingItemEventArgs.cs
@@ -33,23 +33,5 @@ namespace Examine
             ValueSet = valueSet;
             TransformedValues = valueSet.Values.ToDictionary<KeyValuePair<string, IReadOnlyList<object>>, string, IList<object>>(x => x.Key, x => x.Value.ToList());
         }
-
-        /// <summary>
-        /// Sets the values.
-        /// </summary>
-        /// <param name="values">The values.</param>
-        [Obsolete("Set the values on the TransformedValues property instead to prevent unnecessary allocations.")]
-        public void SetValues(IDictionary<string, IEnumerable<object>> values)
-        {
-            TransformedValues.Clear();
-
-            if (values != null)
-            {
-                foreach (KeyValuePair<string, IEnumerable<object>> value in values)
-                {
-                    TransformedValues.Add(value.Key, value.Value.ToList());
-                }
-            }
-        }
     }
 }

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -4,141 +4,206 @@ using System.Linq;
 namespace Examine
 {
     /// <summary>
-    /// Represents an item to be indexed
+    /// Represents an item to be indexed.
     /// </summary>
     public class ValueSet
     {
         /// <summary>
-        /// The id of the object to be indexed
+        /// The identifier of the item to be indexed.
         /// </summary>
         public string Id { get; }
 
         /// <summary>
-        /// The index category
+        /// The index category.
         /// </summary>
         /// <remarks>
-        /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
+        /// Used to categorize the item in the index (in Umbraco terms this would be content, media or member).
         /// </remarks>
         public string Category { get; }
 
         /// <summary>
-        /// The item's node type (in umbraco terms this would be the doc type alias)
+        /// The index item type.
         /// </summary>
+        /// <remarks>
+        /// Used to type the item in the index (in Umbraco terms this would be the document type alias).
+        /// </remarks>
         public string ItemType { get; }
 
         /// <summary>
-        /// The values to be indexed
+        /// The values to be indexed.
         /// </summary>
         public IReadOnlyDictionary<string, IReadOnlyList<object>> Values { get; }
 
         /// <summary>
-        /// Constructor that only specifies an ID
+        /// Initializes a new instance of the <see cref="ValueSet"/> class.
         /// </summary>
-        /// <param name="id"></param>
-        /// <remarks>normally used for deletions</remarks>
-        public ValueSet(string id) => Id = id;
-
-        public static ValueSet FromObject(string id, string category, string itemType, object values)
-            => new ValueSet(id, category, itemType, ObjectExtensions.ConvertObjectToDictionary(values));
-
-        public static ValueSet FromObject(string id, string category, object values)
-            => new ValueSet(id, category, ObjectExtensions.ConvertObjectToDictionary(values));
+        /// <param name="id">The identifier of the object to be indexed.</param>
+        /// <remarks>
+        /// This is normally used for deletions, as it doesn't contain any values.
+        /// </remarks>
+        public ValueSet(string id)
+            : this(id, string.Empty, string.Empty, Enumerable.Empty<KeyValuePair<string, IEnumerable<object>>>())
+        { }
 
         /// <summary>
-        /// Constructor
+        /// Initializes a new instance of the <see cref="ValueSet" /> class.
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="category">
-        /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
-        /// </param>
-        /// <param name="values"></param>
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="values">The values to be indexed.</param>
         public ValueSet(string id, string category, IDictionary<string, object> values)
-            : this(id, category, string.Empty, values)
-        {
-        }
+            : this(id, category, string.Empty, Yield(values))
+        { }
 
         /// <summary>
-        /// Constructor
+        /// Initializes a new instance of the <see cref="ValueSet" /> class.
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="category">
-        /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
-        /// </param>
-        /// <param name="itemType"></param>
-        /// <param name="values"></param>
-        public ValueSet(string id, string category, string itemType, IDictionary<string, object> values)
-            : this(id, category, itemType, values.ToDictionary(x => x.Key, x => Yield(x.Value)))
-        {
-        }
-
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="category">
-        /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
-        /// </param>
-        /// <param name="values"></param>
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="values">The values to be indexed.</param>
         public ValueSet(string id, string category, IDictionary<string, IEnumerable<object>> values)
-            : this(id, category, string.Empty, values)
-        {
-        }
+            : this(id, category, string.Empty, Yield(values))
+        { }
 
         /// <summary>
-        /// Primary constructor
+        /// Initializes a new instance of the <see cref="ValueSet" /> class.
         /// </summary>
-        /// <param name="id"></param>
-        /// <param name="itemType">
-        /// The item's node type (in umbraco terms this would be the doc type alias)</param>
-        /// <param name="category">
-        /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
-        /// </param>
-        /// <param name="values"></param>
-        public ValueSet(string id, string category, string itemType, IDictionary<string, IEnumerable<object>> values)
-            : this(id, category, itemType, values.ToDictionary(x => x.Key, x => (IReadOnlyList<object>)x.Value.ToList()))
-        {
-        }
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="itemType">The index item type. Used to type the item in the index (in Umbraco terms this would be the document type alias).</param>
+        /// <param name="values">The values to be indexed.</param>
+        public ValueSet(string id, string category, string itemType, IDictionary<string, object> values)
+            : this(id, category, itemType, Yield(values))
+        { }
 
-        private ValueSet(string id, string category, string itemType, IReadOnlyDictionary<string, IReadOnlyList<object>> values)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueSet" /> class.
+        /// </summary>
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="itemType">The index item type. Used to type the item in the index (in Umbraco terms this would be the document type alias).</param>
+        /// <param name="values">The values to be indexed.</param>
+        public ValueSet(string id, string category, string itemType, IDictionary<string, IEnumerable<object>> values)
+            : this(id, category, itemType, Yield(values))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueSet" /> class.
+        /// </summary>
+        /// <param name="valueSet">The value set.</param>
+        /// <param name="values">The values to be indexed.</param>
+        public ValueSet(ValueSet valueSet, IDictionary<string, IList<object>> values)
+            : this(valueSet.Id, valueSet.Category, valueSet.ItemType, Yield(values))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueSet" /> class.
+        /// </summary>
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="itemType">The index item type. Used to type the item in the index (in Umbraco terms this would be the document type alias).</param>
+        /// <param name="values">The values to be indexed.</param>
+        /// <remarks>
+        /// This constructor is not public, because we want to ensure values is not null and contains unique keys.
+        /// </remarks>
+        private ValueSet(string id, string category, string itemType, IEnumerable<KeyValuePair<string, IEnumerable<object>>> values)
         {
             Id = id;
             Category = category;
             ItemType = itemType;
-            Values = values.ToDictionary(x => x.Key, x => (IReadOnlyList<object>)x.Value.ToList());
+            Values = AsReadOnly(values);
         }
 
         /// <summary>
-        /// Gets the values for the key
+        /// Gets the values for the key.
         /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public IEnumerable<object> GetValues(string key)
-        {
-            return !Values.TryGetValue(key, out var values) ? Enumerable.Empty<object>() : values;
-        }
-
-        /// <summary>
-        /// Gets a single value for the key
-        /// </summary>
-        /// <param name="key"></param>
+        /// <param name="key">The key.</param>
         /// <returns>
-        /// If there are multiple values, this will return the first
+        /// The values for the specified key.
+        /// </returns>
+        public IEnumerable<object> GetValues(string key)
+            => !Values.TryGetValue(key, out IReadOnlyList<object> values) ? Enumerable.Empty<object>() : values;
+
+        /// <summary>
+        /// Gets the first value for the key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>
+        /// The first value for the specified key.
         /// </returns>
         public object GetValue(string key)
-        {
-            return !Values.TryGetValue(key, out var values) ? null : values.Count > 0 ? values[0] : null;
-        }
+            => !Values.TryGetValue(key, out IReadOnlyList<object> values) || values.Count == 0 ? null : values[0];
 
         /// <summary>
-        /// Helper method to return IEnumerable from a single
+        /// Creates a new <see cref="ValueSet" /> from the specified values.
         /// </summary>
-        /// <param name="i"></param>
-        /// <returns></returns>
-        private static IEnumerable<object> Yield(object i)
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="itemType">The index item type. Used to type the item in the index (in Umbraco terms this would be the document type alias).</param>
+        /// <param name="values">The values to be indexed.</param>
+        /// <returns>
+        /// The value set.
+        /// </returns>
+        public static ValueSet FromObject(string id, string category, string itemType, object values)
+            => new ValueSet(id, category, itemType, ObjectExtensions.ConvertObjectToDictionary(values));
+
+        /// <summary>
+        /// Creates a new <see cref="ValueSet" /> from the specified values.
+        /// </summary>
+        /// <param name="id">The identifier of the item to be indexed.</param>
+        /// <param name="category">The index category. Used to categorize the item in the index (in Umbraco terms this would be content, media or member).</param>
+        /// <param name="values">The values to be indexed.</param>
+        /// <returns>
+        /// The value set.
+        /// </returns>
+        public static ValueSet FromObject(string id, string category, object values)
+            => new ValueSet(id, category, ObjectExtensions.ConvertObjectToDictionary(values));
+
+        private static IEnumerable<KeyValuePair<string, IEnumerable<object>>> Yield(IDictionary<string, object> values)
         {
-            yield return i;
+            if (values is null)
+            {
+                yield break;
+            }
+
+            IEnumerable<object> Yield(object value)
+            {
+                yield return value;
+            }
+
+            foreach (KeyValuePair<string, object> value in values)
+            {
+                yield return new KeyValuePair<string, IEnumerable<object>>(value.Key, Yield(value.Value));
+            }
         }
 
-        public ValueSet Clone() => new ValueSet(Id, Category, ItemType, Values);
+        private static IEnumerable<KeyValuePair<string, IEnumerable<object>>> Yield(IDictionary<string, IEnumerable<object>> values)
+        {
+            if (values is null)
+            {
+                yield break;
+            }
+
+            foreach (KeyValuePair<string, IEnumerable<object>> value in values)
+            {
+                yield return value;
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, IEnumerable<object>>> Yield(IDictionary<string, IList<object>> values)
+        {
+            if (values is null)
+            {
+                yield break;
+            }
+
+            foreach (KeyValuePair<string, IList<object>> value in values)
+            {
+                yield return new KeyValuePair<string, IEnumerable<object>>(value.Key, value.Value);
+            }
+        }
+
+        private static IReadOnlyDictionary<string, IReadOnlyList<object>> AsReadOnly(IEnumerable<KeyValuePair<string, IEnumerable<object>>> values)
+            => values.ToDictionary<KeyValuePair<string, IEnumerable<object>>, string, IReadOnlyList<object>>(x => x.Key, x => x.Value.ToList().AsReadOnly());
     }
 }

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -115,14 +114,47 @@ namespace Examine
         }
 
         /// <summary>
-        /// Gets the values for the key.
+        /// Adds the value.
         /// </summary>
         /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
         /// <returns>
-        /// The values for the specified key.
+        /// The number of values stored for the specified key.
         /// </returns>
-        public IEnumerable<object> GetValues(string key)
-            => !Values.TryGetValue(key, out IList<object> values) ? Enumerable.Empty<object>() : values;
+        public int AddValue(string key, object value)
+        {
+            if (!Values.TryGetValue(key, out IList<object> values))
+            {
+                Values.Add(key, values = new List<object>());
+            }
+
+            values.Add(value);
+
+            return values.Count;
+        }
+
+        /// <summary>
+        /// Adds the values.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        /// The number of values stored for the specified key.
+        /// </returns>
+        public int AddValues(string key, IEnumerable<object> values)
+        {
+            if (!Values.TryGetValue(key, out IList<object> currentValues))
+            {
+                Values.Add(key, currentValues = new List<object>());
+            }
+
+            foreach (var value in values)
+            {
+                currentValues.Add(value);
+            }
+
+            return currentValues.Count;
+        }
 
         /// <summary>
         /// Gets the first value for the key.
@@ -133,6 +165,78 @@ namespace Examine
         /// </returns>
         public object GetValue(string key)
             => !Values.TryGetValue(key, out IList<object> values) || values.Count == 0 ? null : values[0];
+
+        /// <summary>
+        /// Gets the values for the key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>
+        /// The values for the specified key.
+        /// </returns>
+        public IEnumerable<object> GetValues(string key)
+            => !Values.TryGetValue(key, out IList<object> values) ? Enumerable.Empty<object>() : values;
+
+        /// <summary>
+        /// Sets the value for the key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        public void SetValue(string key, object value)
+            => Values[key] = new List<object>
+            {
+                value
+            };
+
+        /// <summary>
+        /// Sets the values for the key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="values">The values.</param>
+        public void SetValues(string key, IEnumerable<object> values)
+            => Values[key] = new List<object>(values);
+
+        /// <summary>
+        /// Adds the value if the key doesn't exist.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        ///   <c>true</c> if the value was added; otherwise, <c>false</c>.
+        /// </returns>
+        public bool TryAddValue(string key, object value)
+        {
+            if (Values.ContainsKey(key))
+            {
+                return false;
+            }
+
+            Values.Add(key, new List<object>
+            {
+                value
+            });
+
+            return true;
+        }
+
+        /// <summary>
+        /// Adds the values if the key doesn't exist.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>
+        ///   <c>true</c> if the values were added; otherwise, <c>false</c>.
+        /// </returns>
+        public bool TryAddValues(string key, IEnumerable<object> values)
+        {
+            if (Values.ContainsKey(key))
+            {
+                return false;
+            }
+
+            Values.Add(key, new List<object>(values));
+
+            return true;
+        }
 
         /// <summary>
         /// Creates a new <see cref="ValueSet" /> from the specified values.

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -239,6 +239,16 @@ namespace Examine
         }
 
         /// <summary>
+        /// Removes the values for the key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>
+        ///   <c>true</c> if the values were removed; otherwise, <c>false</c>.
+        /// </returns>
+        public bool RemoveValues(string key)
+            => Values.Remove(key);
+
+        /// <summary>
         /// Creates a new <see cref="ValueSet" /> from the specified values.
         /// </summary>
         /// <param name="id">The identifier of the item to be indexed.</param>

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -32,7 +33,7 @@ namespace Examine
         /// <summary>
         /// The values to be indexed.
         /// </summary>
-        public IReadOnlyDictionary<string, IReadOnlyList<object>> Values { get; }
+        public IDictionary<string, IList<object>> Values { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueSet"/> class.
@@ -91,9 +92,8 @@ namespace Examine
         /// Initializes a new instance of the <see cref="ValueSet" /> class.
         /// </summary>
         /// <param name="valueSet">The value set.</param>
-        /// <param name="values">The values to be indexed.</param>
-        public ValueSet(ValueSet valueSet, IDictionary<string, IList<object>> values)
-            : this(valueSet.Id, valueSet.Category, valueSet.ItemType, Yield(values))
+        public ValueSet(ValueSet valueSet)
+            : this(valueSet.Id, valueSet.Category, valueSet.ItemType, Yield(valueSet.Values))
         { }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Examine
             Id = id;
             Category = category;
             ItemType = itemType;
-            Values = AsReadOnly(values);
+            Values = values.ToDictionary<KeyValuePair<string, IEnumerable<object>>, string, IList<object>>(x => x.Key, x => x.Value.ToList());
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Examine
         /// The values for the specified key.
         /// </returns>
         public IEnumerable<object> GetValues(string key)
-            => !Values.TryGetValue(key, out IReadOnlyList<object> values) ? Enumerable.Empty<object>() : values;
+            => !Values.TryGetValue(key, out IList<object> values) ? Enumerable.Empty<object>() : values;
 
         /// <summary>
         /// Gets the first value for the key.
@@ -132,7 +132,7 @@ namespace Examine
         /// The first value for the specified key.
         /// </returns>
         public object GetValue(string key)
-            => !Values.TryGetValue(key, out IReadOnlyList<object> values) || values.Count == 0 ? null : values[0];
+            => !Values.TryGetValue(key, out IList<object> values) || values.Count == 0 ? null : values[0];
 
         /// <summary>
         /// Creates a new <see cref="ValueSet" /> from the specified values.
@@ -202,8 +202,5 @@ namespace Examine
                 yield return new KeyValuePair<string, IEnumerable<object>>(value.Key, value.Value);
             }
         }
-
-        private static IReadOnlyDictionary<string, IReadOnlyList<object>> AsReadOnly(IEnumerable<KeyValuePair<string, IEnumerable<object>>> values)
-            => values.ToDictionary<KeyValuePair<string, IEnumerable<object>>, string, IReadOnlyList<object>>(x => x.Key, x => x.Value.ToList().AsReadOnly());
     }
 }

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -698,7 +698,7 @@ namespace Examine.Lucene.Providers
             IIndexFieldValueType indexTypeValueType = FieldValueTypeCollection.GetValueType(ExamineFieldNames.ItemTypeFieldName, FieldValueTypeCollection.ValueTypeFactories.GetRequiredFactory(FieldDefinitionTypes.InvariantCultureIgnoreCase));
             indexTypeValueType.AddValue(doc, valueSet.ItemType);
 
-            foreach (KeyValuePair<string, IReadOnlyList<object>> field in valueSet.Values)
+            foreach (KeyValuePair<string, IList<object>> field in valueSet.Values)
             {
                 //check if we have a defined one
                 if (FieldDefinitions.TryGetValue(field.Key, out FieldDefinition definedFieldDefinition))

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -1049,8 +1049,7 @@ namespace Examine.Lucene.Providers
         /// <param name="performCommit"></param>
         private void ProcessDeleteQueueItem(IndexOperation op, bool performCommit = true)
         {
-
-            //if the id is empty then remove the whole type
+            // If the id is empty, then remove the whole type
             if (!string.IsNullOrEmpty(op.ValueSet.Id))
             {
                 DeleteFromIndex(new Term(ExamineFieldNames.ItemIdFieldName, op.ValueSet.Id), performCommit);
@@ -1061,11 +1060,9 @@ namespace Examine.Lucene.Providers
             }
         }
 
-
         private bool ProcessIndexQueueItem(IndexOperation op)
         {
-
-            //raise the event and assign the value to the returned data from the event
+            // Raise the event and assign the value to the returned data from the event
             var indexingNodeDataArgs = new IndexingItemEventArgs(this, op.ValueSet);
             OnTransformingIndexValues(indexingNodeDataArgs);
             if (indexingNodeDataArgs.Cancel)
@@ -1073,8 +1070,9 @@ namespace Examine.Lucene.Providers
                 return false;
             }
 
-            var d = new Document();
-            AddDocument(d, indexingNodeDataArgs.ValueSet);
+            var document = new Document();
+            var valueSet = new ValueSet(op.ValueSet, indexingNodeDataArgs.TransformedValues);
+            AddDocument(document, valueSet);
 
             return true;
         }

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -261,7 +261,8 @@ namespace Examine.Lucene.Providers
                         break;
                     }
 
-                    var op = new IndexOperation(valueSet, IndexOperationType.Add);
+                    // Create a copy of the value set, so we don't transform and iterate the original instance
+                    var op = new IndexOperation(new ValueSet(valueSet), IndexOperationType.Add);
                     if (ProcessQueueItem(op))
                     {
                         indexedNodes++;
@@ -1062,7 +1063,6 @@ namespace Examine.Lucene.Providers
 
         private bool ProcessIndexQueueItem(IndexOperation op)
         {
-            // Raise the event and assign the value to the returned data from the event
             var indexingNodeDataArgs = new IndexingItemEventArgs(this, op.ValueSet);
             OnTransformingIndexValues(indexingNodeDataArgs);
             if (indexingNodeDataArgs.Cancel)
@@ -1071,8 +1071,7 @@ namespace Examine.Lucene.Providers
             }
 
             var document = new Document();
-            var valueSet = new ValueSet(op.ValueSet, indexingNodeDataArgs.TransformedValues);
-            AddDocument(document, valueSet);
+            AddDocument(document, op.ValueSet);
 
             return true;
         }

--- a/src/Examine.Test/Examine.Lucene/Index/LuceneIndexTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Index/LuceneIndexTests.cs
@@ -265,8 +265,6 @@ namespace Examine.Test.Examine.Lucene.Index
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var indexer = GetTestIndex(luceneDir, new StandardAnalyzer(LuceneInfo.CurrentVersion)))
             {
-
-
                 indexer.IndexItem(new ValueSet(1.ToString(), "content", "test",
                     new Dictionary<string, IEnumerable<object>>
                     {
@@ -303,8 +301,6 @@ namespace Examine.Test.Examine.Lucene.Index
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var indexer = GetTestIndex(luceneDir, new StandardAnalyzer(LuceneInfo.CurrentVersion)))
             {
-
-
                 indexer.IndexItem(ValueSet.FromObject(1.ToString(), "content",
                     new { item1 = "value1", item2 = "value2" }));
 
@@ -325,30 +321,11 @@ namespace Examine.Test.Examine.Lucene.Index
         [Test]
         public void Can_Manipulate_ValueSet_In_TransformingIndexValues_Event()
         {
-            void AddData(object sender, IndexingItemEventArgs e, string key, string value)
-            {
-                var updatedValues = e.ValueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
-
-                updatedValues[key] = new List<object>() { value };
-
-                e.SetValues(updatedValues.ToDictionary(x=>x.Key, x=>(IEnumerable<object>) x.Value));
-            }
-
-            void RemoveData(object sender, IndexingItemEventArgs e, string key)
-            {
-                var updatedValues = e.ValueSet.Values.ToDictionary(x => x.Key, x => x.Value.ToList());
-
-                updatedValues.Remove(key);
-
-                e.SetValues(updatedValues.ToDictionary(x=>x.Key, x=>(IEnumerable<object>) x.Value));
-            }
-
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var indexer = GetTestIndex(luceneDir, new StandardAnalyzer(LuceneInfo.CurrentVersion)))
             {
-
-                indexer.TransformingIndexValues += (sender, e) => AddData(sender, e, "newItem1", "value1");
-                indexer.TransformingIndexValues += (sender, e) => RemoveData(sender, e, "item1");
+                indexer.TransformingIndexValues += (sender, e) => e.ValueSet.SetValue("newItem1", "value1");
+                indexer.TransformingIndexValues += (sender, e) => e.ValueSet.RemoveValues("item1");
 
                 indexer.IndexItem(ValueSet.FromObject(1.ToString(), "content",
                     new { item1 = "value1" }));
@@ -365,17 +342,12 @@ namespace Examine.Test.Examine.Lucene.Index
             }
         }
 
-
-
-
         [Test]
         public void Can_Have_Multiple_Values_In_Fields()
         {
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var indexer = GetTestIndex(luceneDir, new StandardAnalyzer(LuceneInfo.CurrentVersion)))
             {
-
-
                 indexer.IndexItem(new ValueSet(1.ToString(), "content",
                     new Dictionary<string, IEnumerable<object>>
                     {
@@ -413,8 +385,6 @@ namespace Examine.Test.Examine.Lucene.Index
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var indexer = GetTestIndex(luceneDir, new StandardAnalyzer(LuceneInfo.CurrentVersion)))
             {
-
-
                 indexer.IndexItem(ValueSet.FromObject(1.ToString(), "content",
                     new { item1 = "value1", item2 = "value2" }));
 
@@ -444,8 +414,6 @@ namespace Examine.Test.Examine.Lucene.Index
                 new StandardAnalyzer(LuceneInfo.CurrentVersion),
                 new FieldDefinitionCollection(new FieldDefinition("item2", "number"))))
             {
-
-
                 indexer.IndexItem(new ValueSet(1.ToString(), "content",
                     new Dictionary<string, IEnumerable<object>>
                     {


### PR DESCRIPTION
Instead of making `ValueSet` immutable (discussed in https://github.com/Shazwazza/Examine/issues/276, done in https://github.com/Shazwazza/Examine/commit/279c8feb04fc4ec8277731412365164a38d6a12d), this PR ensures the `Values` dictionary is always initialized to a new instance (so the reference isn't shared) and every `IndexOperation` gets its own `ValueSet` clone that can be transformed using the `TransformingIndexValues` event.