### PR TITLE
Facets XML (#311)

### DIFF
--- a/src/Examine.Core/BaseIndexProvider.cs
+++ b/src/Examine.Core/BaseIndexProvider.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 
 namespace Examine
 {
-    /// <inheritdoc />
     /// <summary>
     /// Base class for an Examine Index Provider
     /// </summary>
@@ -34,14 +33,11 @@ namespace Examine
         }
 
         /// <summary>
-        /// Represents a type used to configure the logging system and create instances of
-        /// <see cref="ILogger"/> from the registered Microsoft.Extensions.Logging.ILoggerProviders.
+        /// The factory used to create instances of <see cref="ILogger"/>.
         /// </summary>
         protected ILoggerFactory LoggerFactory { get; }
 
-        /// <summary>
-        /// The index name
-        /// </summary>
+        /// <inheritdoc/>
         public virtual string Name { get; }
 
         /// <summary>
@@ -81,14 +77,11 @@ namespace Examine
 
         #region IIndex members
 
-        /// <summary>
-        /// The default searcher of the index
-        /// </summary>
+        /// <inheritdoc/>
         public abstract ISearcher Searcher { get; }
 
-        /// <inheritdoc />
         /// <summary>
-        /// Validates the items and calls <see cref="M:Examine.Providers.BaseIndexProvider.PerformIndexItems(System.Collections.Generic.IEnumerable{Examine.ValueSet})" />
+        /// Validates the items and calls <see cref="PerformIndexItems(IEnumerable{ValueSet}, Action{IndexOperationEventArgs})"/>
         /// </summary>
         /// <param name="values"></param>
         public void IndexItems(IEnumerable<ValueSet> values)
@@ -102,21 +95,14 @@ namespace Examine
         public void DeleteFromIndex(IEnumerable<string> itemIds)
             => PerformDeleteFromIndex(itemIds, OnIndexOperationComplete);
 
-        /// <summary>
-        /// Creates a new index, any existing index will be deleted
-        /// </summary>
+        /// <inheritdoc/>
         public abstract void CreateIndex();
 
-        /// <summary>
-        /// Returns the mappings for field types to index field types
-        /// </summary>
+        /// <inheritdoc/>
         public ReadOnlyFieldDefinitionCollection FieldDefinitions =>
             _indexOptions.FieldDefinitions ?? new FieldDefinitionCollection();
 
-        /// <summary>
-        /// Check if the index exists
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public abstract bool IndexExists();
 
         #endregion
@@ -143,9 +129,9 @@ namespace Examine
         protected void OnIndexOperationComplete(IndexOperationEventArgs e) => IndexOperationComplete?.Invoke(this, e);
 
         /// <summary>
-        /// Raises the <see cref="E:IndexingError"/> event.
+        /// Raises the <see cref="IndexingError"/> event.
         /// </summary>
-        /// <param name="e">The <see cref="Examine.IndexingErrorEventArgs"/> instance containing the event data.</param>
+        /// <param name="e">The <see cref="IndexingErrorEventArgs"/> instance containing the event data.</param>
         protected virtual void OnIndexingError(IndexingErrorEventArgs e)
         {
             _logger.LogError(e.Exception, e.Message);
@@ -153,7 +139,7 @@ namespace Examine
         }
 
         /// <summary>
-        /// Raises the <see cref="E:TransformingIndexValues"/> event.
+        /// Raises the <see cref="TransformingIndexValues"/> event.
         /// </summary>
         /// <param name="e">The <see cref="IndexingItemEventArgs"/> instance containing the event data.</param>
         protected virtual void OnTransformingIndexValues(IndexingItemEventArgs e) =>

--- a/src/Examine.Core/BaseIndexProvider.cs
+++ b/src/Examine.Core/BaseIndexProvider.cs
@@ -18,9 +18,9 @@ namespace Examine
         /// <summary>
         /// Constructor for creating an indexer at runtime
         /// </summary>
+        /// <param name="loggerFactory"></param>
         /// <param name="name"></param>
-        /// <param name="fieldDefinitions"></param>
-        /// <param name="validator"></param>
+        /// <param name="indexOptions"></param>
         protected BaseIndexProvider(ILoggerFactory loggerFactory, string name,
             IOptionsMonitor<IndexOptions> indexOptions)
         {
@@ -33,7 +33,15 @@ namespace Examine
             _indexOptions = indexOptions.GetNamedOptions(name);
         }
 
+        /// <summary>
+        /// Represents a type used to configure the logging system and create instances of
+        /// <see cref="ILogger"/> from the registered Microsoft.Extensions.Logging.ILoggerProviders.
+        /// </summary>
         protected ILoggerFactory LoggerFactory { get; }
+
+        /// <summary>
+        /// The index name
+        /// </summary>
         public virtual string Name { get; }
 
         /// <summary>
@@ -73,6 +81,9 @@ namespace Examine
 
         #region IIndex members
 
+        /// <summary>
+        /// The default searcher of the index
+        /// </summary>
         public abstract ISearcher Searcher { get; }
 
         /// <inheritdoc />
@@ -125,6 +136,10 @@ namespace Examine
 
         #region Protected Event callers
 
+        /// <summary>
+        /// Run when a index operation completes
+        /// </summary>
+        /// <param name="e"></param>
         protected void OnIndexOperationComplete(IndexOperationEventArgs e) => IndexOperationComplete?.Invoke(this, e);
 
         /// <summary>

--- a/src/Examine.Core/BaseSearchProvider.cs
+++ b/src/Examine.Core/BaseSearchProvider.cs
@@ -8,19 +8,21 @@ namespace Examine
     ///</summary>
     public abstract class BaseSearchProvider : ISearcher
     {
+        /// <inheritdoc/>
         protected BaseSearchProvider(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
             Name = name;
         }
 
+        /// <inheritdoc/>
         public string Name { get; }
 
         /// <summary>
         /// Searches the index
         /// </summary>
         /// <param name="searchText"></param>
-        /// <param name="maxResults"></param>
+        /// <param name="options"></param>
         /// <returns></returns>
         public abstract ISearchResults Search(string searchText, QueryOptions options = null);
 

--- a/src/Examine.Core/BaseSearchProvider.cs
+++ b/src/Examine.Core/BaseSearchProvider.cs
@@ -18,12 +18,7 @@ namespace Examine
         /// <inheritdoc/>
         public string Name { get; }
 
-        /// <summary>
-        /// Searches the index
-        /// </summary>
-        /// <param name="searchText"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public abstract ISearchResults Search(string searchText, QueryOptions options = null);
 
         /// <inheritdoc />

--- a/src/Examine.Core/DisposableObjectSlim.cs
+++ b/src/Examine.Core/DisposableObjectSlim.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Examine
 {   
@@ -10,11 +10,13 @@ namespace Examine
     {
         private readonly object _locko = new object();
 
-        // gets a value indicating whether this instance is disposed.
-        // for internal tests only (not thread safe)
+        /// <summary>
+        /// Gets a value indicating whether this instance is disposed.
+        /// for internal tests only (not thread safe)
+        /// </summary>
         protected bool Disposed { get; private set; }
 
-        // implements IDisposable
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(true);
@@ -32,6 +34,9 @@ namespace Examine
                 DisposeResources();
         }
 
+        /// <summary>
+        /// Used to dispose resources
+        /// </summary>
         protected abstract void DisposeResources();
     }
 }

--- a/src/Examine.Core/EmptySearchResults.cs
+++ b/src/Examine.Core/EmptySearchResults.cs
@@ -4,31 +4,42 @@ using System.Linq;
 
 namespace Examine
 {
+    /// <summary>
+    /// Represents <see cref="ISearchResults"/> with no elements
+    /// </summary>
 	public sealed class EmptySearchResults : ISearchResults
 	{
         private EmptySearchResults()
         {   
         }
 
+        /// <summary>
+        /// Gets the static instance
+        /// </summary>
 	    public static ISearchResults Instance { get; } = new EmptySearchResults();
 
+        /// <inheritdoc/>
         public IEnumerator<ISearchResult> GetEnumerator()
 		{
 			return Enumerable.Empty<ISearchResult>().GetEnumerator();
 		}
 
-		IEnumerator IEnumerable.GetEnumerator()
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
 		{
 			return Enumerable.Empty<ISearchResult>().GetEnumerator();
 		}
 
+        /// <inheritdoc/>
 		public long TotalItemCount => 0;
 
-	    public IEnumerable<ISearchResult> Skip(int skip)
+        /// <inheritdoc/>
+        public IEnumerable<ISearchResult> Skip(int skip)
 		{
 			return Enumerable.Empty<ISearchResult>();
 		}
 
+        /// <inheritdoc/>
         public IEnumerable<ISearchResult> SkipTake(int skip, int? take = null)
         {
 			return Enumerable.Empty<ISearchResult>();

--- a/src/Examine.Core/Examine.Core.csproj
+++ b/src/Examine.Core/Examine.Core.csproj
@@ -5,6 +5,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>Examine is an abstraction for indexing and search operations with implementations such as Lucene.Net</Description>
     <PackageTags>examine search index</PackageTags>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examine.Core/ExamineExtensions.cs
+++ b/src/Examine.Core/ExamineExtensions.cs
@@ -8,6 +8,14 @@ namespace Examine
     /// </summary>
     public static class ExamineExtensions
     {
+        /// <summary>
+        /// Gets named options from an <see cref="IOptionsMonitor{TOptions}"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="optionsMonitor"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public static T GetNamedOptions<T>(this IOptionsMonitor<T> optionsMonitor, string name)
             where T : class
         {
@@ -36,6 +44,11 @@ namespace Examine
             throw new InvalidOperationException("No index found with name " + indexName);
         }
 
+        /// <summary>
+        /// Deletes a node from the index
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="itemId"></param>
         public static void DeleteFromIndex(this IIndex index, string itemId)
         {
             index.DeleteFromIndex(new[] {itemId});

--- a/src/Examine.Core/ExamineFieldNames.cs
+++ b/src/Examine.Core/ExamineFieldNames.cs
@@ -1,5 +1,8 @@
 namespace Examine
 {
+    /// <summary>
+    /// Constant names for speciffic fields
+    /// </summary>
     public static class ExamineFieldNames
     {
         /// <summary>
@@ -22,6 +25,9 @@ namespace Examine
         /// </summary>
         public const string ItemIdFieldName = "__NodeId";
 
+        /// <summary>
+        /// Used to store the item type for a document
+        /// </summary>
         public const string ItemTypeFieldName = "__NodeTypeAlias";
 
         /// <summary>

--- a/src/Examine.Core/ExamineManager.cs
+++ b/src/Examine.Core/ExamineManager.cs
@@ -10,6 +10,7 @@ namespace Examine
     ///</summary>
     public class ExamineManager : IDisposable, IExamineManager
     {
+        /// <inheritdoc/>
         public ExamineManager(IEnumerable<IIndex> indexes, IEnumerable<ISearcher> searchers)
         {
             foreach(IIndex i in indexes)
@@ -68,6 +69,8 @@ namespace Examine
         public void Dispose() => Dispose(true);
 
         private bool _disposed = false;
+
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/src/Examine.Core/FieldDefinition.cs
+++ b/src/Examine.Core/FieldDefinition.cs
@@ -30,14 +30,17 @@ namespace Examine
         /// </summary>
         public string Type { get; }
 
+        /// <inheritdoc/>
         public bool Equals(FieldDefinition other) => string.Equals(Name, other.Name) && string.Equals(Type, other.Type);
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             return obj is FieldDefinition definition && Equals(definition);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -46,8 +49,10 @@ namespace Examine
             }
         }
 
+        /// <inheritdoc/>
         public static bool operator ==(FieldDefinition left, FieldDefinition right) => left.Equals(right);
 
+        /// <inheritdoc/>
         public static bool operator !=(FieldDefinition left, FieldDefinition right) => !left.Equals(right);
     }
 }

--- a/src/Examine.Core/FieldDefinitionCollection.cs
+++ b/src/Examine.Core/FieldDefinitionCollection.cs
@@ -2,16 +2,29 @@ using System;
 
 namespace Examine
 {
+    /// <inheritdoc/>
     public class FieldDefinitionCollection : ReadOnlyFieldDefinitionCollection
     {
+        /// <inheritdoc/>
         public FieldDefinitionCollection(params FieldDefinition[] definitions) : base(definitions)
         {
         }
 
+        /// <inheritdoc/>
         public FieldDefinitionCollection()
         {
         }
 
+        /// <summary>
+        /// Adds a key/value pair to the System.Collections.Concurrent.ConcurrentDictionary`2
+        /// by using the specified function if the key does not already exist, or returns
+        /// the existing value if the key exists.
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <param name="add"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">fieldName or add is null</exception>
+        /// <exception cref="OverflowException">The dictionary already contains the maximum number of elements (<see cref="int.MaxValue"/>)</exception>
         public FieldDefinition GetOrAdd(string fieldName, Func<string, FieldDefinition> add) => Definitions.GetOrAdd(fieldName, add);
 
         /// <summary>
@@ -20,6 +33,16 @@ namespace Examine
         /// <param name="definition"></param>
         public void AddOrUpdate(FieldDefinition definition) => Definitions.AddOrUpdate(definition.Name, definition, (s, factory) => definition);
 
+        /// <summary>
+        /// Attempts to add the specified key and value to the System.Collections.Concurrent.ConcurrentDictionary`2.
+        /// </summary>
+        /// <param name="definition"></param>
+        /// <returns>
+        /// True if the key/value pair was added to the System.Collections.Concurrent.ConcurrentDictionary`2
+        /// successfully; false if the key already exists.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">definition.Name is null</exception>
+        /// <exception cref="OverflowException">The dictionary already contains the maximum number of elements (<see cref="int.MaxValue"/>)</exception>
         public bool TryAdd(FieldDefinition definition) => Definitions.TryAdd(definition.Name, definition);
     }
 }

--- a/src/Examine.Core/FieldDefinitionCollection.cs
+++ b/src/Examine.Core/FieldDefinitionCollection.cs
@@ -16,7 +16,7 @@ namespace Examine
         }
 
         /// <summary>
-        /// Adds a key/value pair to the System.Collections.Concurrent.ConcurrentDictionary`2
+        /// Adds a key/value pair to the <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>
         /// by using the specified function if the key does not already exist, or returns
         /// the existing value if the key exists.
         /// </summary>
@@ -34,11 +34,11 @@ namespace Examine
         public void AddOrUpdate(FieldDefinition definition) => Definitions.AddOrUpdate(definition.Name, definition, (s, factory) => definition);
 
         /// <summary>
-        /// Attempts to add the specified key and value to the System.Collections.Concurrent.ConcurrentDictionary`2.
+        /// Attempts to add the specified key and value to the <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>.
         /// </summary>
         /// <param name="definition"></param>
         /// <returns>
-        /// True if the key/value pair was added to the System.Collections.Concurrent.ConcurrentDictionary`2
+        /// True if the key/value pair was added to the <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>
         /// successfully; false if the key already exists.
         /// </returns>
         /// <exception cref="ArgumentNullException">definition.Name is null</exception>

--- a/src/Examine.Core/FieldDefinitionTypes.cs
+++ b/src/Examine.Core/FieldDefinitionTypes.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Examine
 {
     /// <summary>
@@ -5,15 +7,54 @@ namespace Examine
     /// </summary>
     public static class FieldDefinitionTypes
     {
+        /// <summary>
+        /// Will be indexed as an integer
+        /// </summary>
         public const string Integer = "int";
+
+        /// <summary>
+        /// Will be indexed as a float
+        /// </summary>
         public const string Float = "float";
+
+        /// <summary>
+        /// Will be indexed as a double
+        /// </summary>
         public const string Double = "double";
+
+        /// <summary>
+        /// Will be indexed as a long
+        /// </summary>
         public const string Long = "long";
+
+        /// <summary>
+        /// Will be indexed DateTime represented as a long
+        /// </summary>
         public const string DateTime = "datetime";
+
+        /// <summary>
+        /// Will be indexed DateTime but with precision only to the year represented as a long
+        /// </summary>
         public const string DateYear = "date.year";
+
+        /// <summary>
+        /// Will be indexed DateTime but with precision only to the month represented as a long
+        /// </summary>
         public const string DateMonth = "date.month";
+
+        /// <summary>
+        /// Will be indexed DateTime but with precision only to the day represented as a long
+        /// </summary>
         public const string DateDay = "date.day";
+
+        /// <summary>
+        /// Will be indexed DateTime but with precision only to the hour represented as a long
+        /// </summary>
         public const string DateHour = "date.hour";
+
+        /// <summary>
+        /// Will be indexed DateTime but with precision only to the minute represented as a long
+        /// </summary>
         public const string DateMinute = "date.minute";
 
         /// <summary>

--- a/src/Examine.Core/IExamineManager.cs
+++ b/src/Examine.Core/IExamineManager.cs
@@ -3,6 +3,9 @@ using System.Linq;
 
 namespace Examine
 {
+    /// <summary>
+    /// Exposes searchers and indexers
+    /// </summary>
     public interface IExamineManager
     {
         /// <summary>
@@ -17,10 +20,13 @@ namespace Examine
         /// Gets a list of all manually configured search providers
         /// </summary>
         /// <remarks>
-        /// This returns only those searchers explicitly registered with <see cref="AddSearcher"/> or config based searchers
+        /// This returns only those searchers explicitly registered with AddExamineSearcher or config based searchers
         /// </remarks>
         IEnumerable<ISearcher> RegisteredSearchers { get; }
 
+        /// <summary>
+        /// Disposes the <see cref="IExamineManager"/>
+        /// </summary>
         void Dispose();
 
         /// <summary>
@@ -32,7 +38,7 @@ namespace Examine
         bool TryGetIndex(string indexName, out IIndex index);
 
         /// <summary>
-        /// Returns a searcher that was registered with <see cref="AddSearcher"/> or via config
+        /// Returns a searcher that was registered with AddExamineSearcher or via config
         /// </summary>
         /// <param name="searcherName"></param>
         /// <param name="searcher"></param>

--- a/src/Examine.Core/IIndex.cs
+++ b/src/Examine.Core/IIndex.cs
@@ -9,6 +9,9 @@ namespace Examine
     /// </summary>
     public interface IIndex
     {
+        /// <summary>
+        /// The index name
+        /// </summary>
         string Name { get; }
 
         /// <summary>

--- a/src/Examine.Core/IIndexStats.cs
+++ b/src/Examine.Core/IIndexStats.cs
@@ -3,9 +3,21 @@ using System.Threading.Tasks;
 
 namespace Examine
 {
+    /// <summary>
+    /// Represents stats for a <see cref="IIndex"/>
+    /// </summary>
     public interface IIndexStats
     {
+        /// <summary>
+        /// Gets the ammount of documents in the index
+        /// </summary>
+        /// <returns></returns>
         long GetDocumentCount();
+
+        /// <summary>
+        /// Gets the field names in the index
+        /// </summary>
+        /// <returns></returns>
         IEnumerable<string> GetFieldNames();
     }
 }

--- a/src/Examine.Core/ISearchResult.cs
+++ b/src/Examine.Core/ISearchResult.cs
@@ -1,11 +1,20 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Examine
 {
+    /// <summary>
+    /// Represents a search result
+    /// </summary>
     public interface ISearchResult
     {
+        /// <summary>
+        /// The id of the search result
+        /// </summary>
         string Id { get; }
 
+        /// <summary>
+        /// The score of the search result
+        /// </summary>
         float Score { get; }
 
         /// <summary>

--- a/src/Examine.Core/ISearchResults.cs
+++ b/src/Examine.Core/ISearchResults.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 
 namespace Examine
 {
+    /// <summary>
+    /// Represents search results from a query
+    /// </summary>
     public interface ISearchResults : IEnumerable<ISearchResult>
     {
         /// <summary>

--- a/src/Examine.Core/ISearcher.cs
+++ b/src/Examine.Core/ISearcher.cs
@@ -7,13 +7,16 @@ namespace Examine
     /// </summary>
     public interface ISearcher
     {
+        /// <summary>
+        /// The searchers name
+        /// </summary>
         string Name { get; }
 
         /// <summary>
         /// Searches the index
         /// </summary>
         /// <param name="searchText">The search text or a native query</param>
-        /// <param name="maxResults"></param>
+        /// <param name="options"></param>
         /// <returns>Search Results</returns>
         ISearchResults Search(string searchText, QueryOptions options = null);
 

--- a/src/Examine.Core/IValueSetValidator.cs
+++ b/src/Examine.Core/IValueSetValidator.cs
@@ -5,6 +5,11 @@ namespace Examine
     /// </summary>
     public interface IValueSetValidator
     {
+        /// <summary>
+        /// Validates the value set
+        /// </summary>
+        /// <param name="valueSet"></param>
+        /// <returns></returns>
         ValueSetValidationResult Validate(ValueSet valueSet);
     }
 }

--- a/src/Examine.Core/IndexOperationEventArgs.cs
+++ b/src/Examine.Core/IndexOperationEventArgs.cs
@@ -2,11 +2,22 @@ using System;
 
 namespace Examine
 {
+    /// <summary>
+    /// Represents index operation event arguments
+    /// </summary>
     public class IndexOperationEventArgs : EventArgs
     {
+        /// <summary>
+        /// The index of the event
+        /// </summary>
         public IIndex Index { get; }
+
+        /// <summary>
+        /// The items indexed in operation
+        /// </summary>
         public int ItemsIndexed { get; }
 
+        /// <inheritdoc/>
         public IndexOperationEventArgs(IIndex index, int itemsIndexed)
         {
             Index = index;

--- a/src/Examine.Core/IndexOperationType.cs
+++ b/src/Examine.Core/IndexOperationType.cs
@@ -5,7 +5,14 @@ namespace Examine
     /// </summary>
     public enum IndexOperationType
     {
+        /// <summary>
+        /// An additive operation
+        /// </summary>
         Add,
+
+        /// <summary>
+        /// A delete operation
+        /// </summary>
         Delete
     }
 }

--- a/src/Examine.Core/IndexOptions.cs
+++ b/src/Examine.Core/IndexOptions.cs
@@ -1,10 +1,21 @@
 namespace Examine
 {
+    /// <summary>
+    /// Represents the index options for a <see cref="IIndex"/>
+    /// </summary>
     public class IndexOptions
     {
+        /// <inheritdoc/>
         public IndexOptions() => FieldDefinitions = new FieldDefinitionCollection();
 
+        /// <summary>
+        /// The field definitions for the <see cref="IIndex"/>
+        /// </summary>
         public FieldDefinitionCollection FieldDefinitions { get; set; }
+
+        /// <summary>
+        /// The validator for the <see cref="IIndex"/>
+        /// </summary>
         public IValueSetValidator Validator { get; set; }
     }
 }

--- a/src/Examine.Core/IndexingErrorEventArgs.cs
+++ b/src/Examine.Core/IndexingErrorEventArgs.cs
@@ -5,9 +5,12 @@ using System.Text;
 
 namespace Examine
 {
+    /// <summary>
+    /// Indexing error event arguments
+    /// </summary>
     public class IndexingErrorEventArgs : EventArgs
     {
-
+        /// <inheritdoc/>
         public IndexingErrorEventArgs(IIndex index, string message, string itemId, Exception exception)
         {
             Index = index;
@@ -16,9 +19,24 @@ namespace Examine
             Exception = exception;
         }
 
+        /// <summary>
+        /// The exception of the error
+        /// </summary>
         public Exception Exception { get; }
+
+        /// <summary>
+        /// The message of the error
+        /// </summary>
         public string Message { get; }
+
+        /// <summary>
+        /// The index where the error originated
+        /// </summary>
         public IIndex Index { get; }
+
+        /// <summary>
+        /// The item id
+        /// </summary>
         public string ItemId { get; }
     }
 }

--- a/src/Examine.Core/IndexingItemEventArgs.cs
+++ b/src/Examine.Core/IndexingItemEventArgs.cs
@@ -4,18 +4,32 @@ using System.ComponentModel;
 
 namespace Examine
 {
+    /// <summary>
+    /// Represents indexing item event arguments
+    /// </summary>
     public class IndexingItemEventArgs : CancelEventArgs
     {
+        /// <summary>
+        /// The index of the event
+        /// </summary>
         public IIndex Index { get; }
 
+        /// <summary>
+        /// The value set of the event
+        /// </summary>
         public ValueSet ValueSet { get; private set; }
 
+        /// <inheritdoc/>
         public IndexingItemEventArgs(IIndex index, ValueSet valueSet)
         {
             Index = index;
             ValueSet = valueSet;
         }
 
+        /// <summary>
+        /// Sets the value of the <see cref="ValueSet"/>
+        /// </summary>
+        /// <param name="values"></param>
         public void SetValues(IDictionary<string, IEnumerable<object>> values)
             => ValueSet = new ValueSet(ValueSet.Id, ValueSet.Category, ValueSet.ItemType, values);
     }

--- a/src/Examine.Core/ObjectExtensions.cs
+++ b/src/Examine.Core/ObjectExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -14,6 +14,9 @@ using System.Xml;
 
 namespace Examine
 {
+    /// <summary>
+    /// Extensions for objects
+    /// </summary>
     public static class ObjectExtensions
     {
         /// <summary>

--- a/src/Examine.Core/OrderedDictionary.cs
+++ b/src/Examine.Core/OrderedDictionary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -12,14 +12,17 @@ namespace Examine
     /// <typeparam name="TVal"></typeparam>
     public class OrderedDictionary<TKey, TVal> : KeyedCollection<TKey, KeyValuePair<TKey, TVal>>, IDictionary<TKey, TVal>, IReadOnlyDictionary<TKey, TVal>
     {
+        /// <inheritdoc/>
         public OrderedDictionary()
         {
         }
 
+        /// <inheritdoc/>
         public OrderedDictionary(IEqualityComparer<TKey> comparer) : base(comparer)
         {
         }
-        
+
+        /// <inheritdoc/>
         public TVal GetItem(int index)
         {
             if (index >= Count) throw new IndexOutOfRangeException();
@@ -29,6 +32,7 @@ namespace Examine
             return base[found.Key].Value;
         }
 
+        /// <inheritdoc/>
         public int IndexOf(TKey key)
         {
             if (base.Dictionary == null) return -1;
@@ -39,16 +43,19 @@ namespace Examine
             return -1;
         }
 
+        /// <inheritdoc/>
         protected override TKey GetKeyForItem(KeyValuePair<TKey, TVal> item)
         {
             return item.Key;
         }
 
+        /// <inheritdoc/>
         public bool ContainsKey(TKey key)
         {            
             return base.Contains(key);
         }
 
+        /// <inheritdoc/>
         public void Add(TKey key, TVal value)
         {
             if (base.Contains(key)) throw new ArgumentException("The key " + key + " already exists in this collection");
@@ -56,6 +63,7 @@ namespace Examine
             base.Add(new KeyValuePair<TKey, TVal>(key, value));
         }
 
+        /// <inheritdoc/>
         public bool TryGetValue(TKey key, out TVal value)
         {
             if (base.Dictionary == null)
@@ -109,8 +117,10 @@ namespace Examine
         private static readonly ICollection<TKey> EmptyCollection = new List<TKey>();
         private static readonly ICollection<TVal> EmptyValues = new List<TVal>();
 
+        /// <inheritdoc/>
         public ICollection<TKey> Keys => base.Dictionary != null ? base.Dictionary.Keys : EmptyCollection;
 
+        /// <inheritdoc/>
         public ICollection<TVal> Values => base.Dictionary != null ? base.Dictionary.Values.Select(x => x.Value).ToArray() : EmptyValues;
     }
 }

--- a/src/Examine.Core/ReadOnlyFieldDefinitionCollection.cs
+++ b/src/Examine.Core/ReadOnlyFieldDefinitionCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -11,17 +11,20 @@ namespace Examine
     /// </summary>
     public class ReadOnlyFieldDefinitionCollection : IEnumerable<FieldDefinition>
     {
+        /// <inheritdoc/>
         public ReadOnlyFieldDefinitionCollection()
             : this(Enumerable.Empty<FieldDefinition>())
         {   
         }
 
+        /// <inheritdoc/>
         public ReadOnlyFieldDefinitionCollection(params FieldDefinition[] definitions)
             : this((IEnumerable<FieldDefinition>)definitions)
         {
             
         }
 
+        /// <inheritdoc/>
         public ReadOnlyFieldDefinitionCollection(IEnumerable<FieldDefinition> definitions)
         {
             if (definitions == null) return;
@@ -50,12 +53,20 @@ namespace Examine
         /// </remarks>
         public virtual bool TryGetValue(string fieldName, out FieldDefinition fieldDefinition) => Definitions.TryGetValue(fieldName, out fieldDefinition);
 
+        /// <summary>
+        /// Gets the ammount of key/value paris in the <see cref="Definitions"/> collection
+        /// </summary>
         public int Count => Definitions.Count;
 
+        /// <summary>
+        /// A collection of field definitions
+        /// </summary>
         protected ConcurrentDictionary<string, FieldDefinition> Definitions { get; } = new ConcurrentDictionary<string, FieldDefinition>(StringComparer.InvariantCultureIgnoreCase);
 
+        /// <inheritdoc/>
         public IEnumerator<FieldDefinition> GetEnumerator() => Definitions.Values.GetEnumerator();
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Examine.Core/Search/BooleanOperation.cs
+++ b/src/Examine.Core/Search/BooleanOperation.cs
@@ -1,7 +1,23 @@
-﻿namespace Examine.Search
+namespace Examine.Search
 {
+    /// <summary>
+    /// Represents types of boolean operations
+    /// </summary>
     public enum BooleanOperation
     {
-        And, Or, Not
+        /// <summary>
+        /// And modifier
+        /// </summary>
+        And,
+
+        /// <summary>
+        /// Or modifier
+        /// </summary>
+        Or,
+
+        /// <summary>
+        /// Not modifier
+        /// </summary>
+        Not
     }
 }

--- a/src/Examine.Core/Search/ExamineValue.cs
+++ b/src/Examine.Core/Search/ExamineValue.cs
@@ -1,14 +1,17 @@
-﻿using Examine.Search;
+using Examine.Search;
 
 namespace Examine.Search
 {
+    /// <inheritdoc/>
     public struct ExamineValue : IExamineValue
     {
+        /// <inheritdoc/>
         public ExamineValue(Examineness vagueness, string value)
             : this(vagueness, value, 1)
         {
         }
 
+        /// <inheritdoc/>
         public ExamineValue(Examineness vagueness, string value, float level)
         {
             Examineness = vagueness;
@@ -16,10 +19,13 @@ namespace Examine.Search
             Level = level;
         }
 
+        /// <inheritdoc/>
         public Examineness Examineness { get; }
 
+        /// <inheritdoc/>
         public string Value { get; }
 
+        /// <inheritdoc/>
         public float Level { get; }
 
     }

--- a/src/Examine.Core/Search/FacetResult.cs
+++ b/src/Examine.Core/Search/FacetResult.cs
@@ -37,6 +37,7 @@ namespace Examine.Search
             return _dictValues[label];
         }
 
+        /// <inheritdoc/>
         public bool TryGetFacet(string label, out IFacetValue facetValue)
         {
             SetValuesDictionary();

--- a/src/Examine.Core/Search/FacetResult.cs
+++ b/src/Examine.Core/Search/FacetResult.cs
@@ -4,16 +4,19 @@ using System.Linq;
 
 namespace Examine.Search
 {
+    /// <inheritdoc/>
     public class FacetResult : IFacetResult
     {
         private readonly IEnumerable<IFacetValue> _values;
         private IDictionary<string, IFacetValue> _dictValues;
 
+        /// <inheritdoc/>
         public FacetResult(IEnumerable<IFacetValue> values)
         {
             _values = values;
         }
 
+        /// <inheritdoc/>
         public IEnumerator<IFacetValue> GetEnumerator()
         {
             return _values.GetEnumerator();
@@ -27,6 +30,7 @@ namespace Examine.Search
             }
         }
 
+        /// <inheritdoc/>
         public IFacetValue Facet(string label)
         {
             SetValuesDictionary();
@@ -39,6 +43,7 @@ namespace Examine.Search
             return _dictValues.TryGetValue(label, out facetValue);
         }
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();

--- a/src/Examine.Core/Search/FacetValue.cs
+++ b/src/Examine.Core/Search/FacetValue.cs
@@ -1,11 +1,15 @@
 namespace Examine.Search
 {
+    /// <inheritdoc/>
     public readonly struct FacetValue : IFacetValue
     {
+        /// <inheritdoc/>
         public string Label { get; }
 
+        /// <inheritdoc/>
         public float Value { get; }
 
+        /// <inheritdoc/>
         public FacetValue(string label, float value)
         {
             Label = label;

--- a/src/Examine.Core/Search/IExamineValue.cs
+++ b/src/Examine.Core/Search/IExamineValue.cs
@@ -1,10 +1,24 @@
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a value used in a query like <see cref="IQuery"/>
+    /// </summary>
     public interface IExamineValue
     {
+        /// <summary>
+        /// Different ways to match terms
+        /// </summary>
         Examineness Examineness { get; }
+
+        /// <summary>
+        /// The level
+        /// </summary>
         float Level { get; }
+
+        /// <summary>
+        /// The value
+        /// </summary>
         string Value { get; }
     }
 }

--- a/src/Examine.Core/Search/IFacetQueryField.cs
+++ b/src/Examine.Core/Search/IFacetQueryField.cs
@@ -1,5 +1,8 @@
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a facet fulltext query field
+    /// </summary>
     public interface IFacetQueryField
     {
         /// <summary>

--- a/src/Examine.Core/Search/IFacetResult.cs
+++ b/src/Examine.Core/Search/IFacetResult.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a facet results consisting of <see cref="IFacetValue"/>
+    /// </summary>
     public interface IFacetResult : IEnumerable<IFacetValue>
     {
         /// <summary>

--- a/src/Examine.Core/Search/IFacetResult.cs
+++ b/src/Examine.Core/Search/IFacetResult.cs
@@ -13,5 +13,13 @@ namespace Examine.Search
         /// <param name="label"></param>
         /// <returns></returns>
         IFacetValue Facet(string label);
+
+        /// <summary>
+        /// Trys to get a facet value for a label
+        /// </summary>
+        /// <param name="label"></param>
+        /// <param name="facetValue"></param>
+        /// <returns></returns>
+        bool TryGetFacet(string label, out IFacetValue facetValue);
     }
 }

--- a/src/Examine.Core/Search/IFacetResults.cs
+++ b/src/Examine.Core/Search/IFacetResults.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a search result containing facets
+    /// </summary>
     public interface IFacetResults
     {
         /// <summary>

--- a/src/Examine.Core/Search/IFacetValue.cs
+++ b/src/Examine.Core/Search/IFacetValue.cs
@@ -1,5 +1,8 @@
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a single facet value
+    /// </summary>
     public interface IFacetValue
     {
         /// <summary>

--- a/src/Examine.Core/Search/INestedBooleanOperation.cs
+++ b/src/Examine.Core/Search/INestedBooleanOperation.cs
@@ -1,7 +1,10 @@
-﻿using System;
+using System;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a nested boolean operation
+    /// </summary>
     public interface INestedBooleanOperation
     {
         /// <summary>

--- a/src/Examine.Core/Search/INestedQuery.cs
+++ b/src/Examine.Core/Search/INestedQuery.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a nested query
+    /// </summary>
     public interface INestedQuery
     {
-
-
         /// <summary>
         /// Query on the specified field for a struct value which will try to be auto converted with the correct query
         /// </summary>

--- a/src/Examine.Core/Search/IOrdering.cs
+++ b/src/Examine.Core/Search/IOrdering.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents a ordering operation
+    /// </summary>
     public interface IOrdering : IQueryExecutor
     {
         /// <summary>
@@ -29,7 +32,7 @@ namespace Examine.Search
         /// <summary>
         /// Return only the specified field. Use <see cref="SelectFields(ISet{string})"/> when possible as internally a new HashSet is created on each call
         /// </summary>
-        /// <param name="fieldNames">The field name of the field to load</param>
+        /// <param name="fieldName">The field name of the field to load</param>
         /// <returns></returns>
         IOrdering SelectField(string fieldName);
 

--- a/src/Examine.Core/Search/OrderingExtensions.cs
+++ b/src/Examine.Core/Search/OrderingExtensions.cs
@@ -1,12 +1,16 @@
-﻿using System;
+using System;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Extensions on the <see cref="IOrdering"/> interface
+    /// </summary>
     public static class OrderingExtensions
     {
         /// <summary>
         /// Allows for selecting facets to return in your query
         /// </summary>
+        /// <param name="ordering"></param>
         /// <param name="facets"></param>
         /// <returns></returns>
         public static IQueryExecutor WithFacets(this IOrdering ordering, Action<IFacetOperations> facets)

--- a/src/Examine.Core/Search/QueryOptions.cs
+++ b/src/Examine.Core/Search/QueryOptions.cs
@@ -2,12 +2,30 @@ using System;
 
 namespace Examine.Search
 {
+    /// <summary>
+    /// Represents options for querying
+    /// </summary>
     public class QueryOptions
     {
+        /// <summary>
+        /// The default maximum ammount of results
+        /// </summary>
         public const int DefaultMaxResults = 500;
+
+        /// <summary>
+        /// Creates a <see cref="QueryOptions"/> with the specified parameters
+        /// </summary>
+        /// <param name="skip"></param>
+        /// <param name="take"></param>
+        /// <returns></returns>
         public static QueryOptions SkipTake(int skip, int? take = null) => new QueryOptions(skip, take ?? DefaultMaxResults);
+
+        /// <summary>
+        /// Creates a default <see cref="QueryOptions"/>
+        /// </summary>
         public static QueryOptions Default { get; } = new QueryOptions(0, DefaultMaxResults);
 
+        /// <inheritdoc/>
         public QueryOptions(int skip, int? take = null)
         {
             if (skip < 0)
@@ -24,7 +42,14 @@ namespace Examine.Search
             Take = take ?? DefaultMaxResults;
         }
 
+        /// <summary>
+        /// The ammount of items to skip
+        /// </summary>
         public int Skip { get; }
+
+        /// <summary>
+        /// The ammount of items to take
+        /// </summary>
         public int Take { get; }
     }
 }

--- a/src/Examine.Core/SearchResult.cs
+++ b/src/Examine.Core/SearchResult.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 
 namespace Examine
 {
+    /// <inheritdoc/>
     public class SearchResult : ISearchResult
     {
         private OrderedDictionary<string, string> _fields;
@@ -33,7 +34,10 @@ namespace Examine
             });
         }
 
+        /// <inheritdoc/>
         public string Id { get;  }
+
+        /// <inheritdoc/>
         public float Score { get; }
 
         /// <summary>

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -38,9 +38,24 @@ namespace Examine
         /// <remarks>normally used for deletions</remarks>
         public ValueSet(string id) => Id = id;
 
+        /// <summary>
+        /// Creates a value set from an object
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="category"></param>
+        /// <param name="itemType"></param>
+        /// <param name="values"></param>
+        /// <returns></returns>
         public static ValueSet FromObject(string id, string category, string itemType, object values)
             => new ValueSet(id, category, itemType, ObjectExtensions.ConvertObjectToDictionary(values));
 
+       /// <summary>
+       /// Creates a value set from an object
+       /// </summary>
+       /// <param name="id"></param>
+       /// <param name="category"></param>
+       /// <param name="values"></param>
+       /// <returns></returns>
         public static ValueSet FromObject(string id, string category, object values)
             => new ValueSet(id, category, ObjectExtensions.ConvertObjectToDictionary(values));
 
@@ -139,6 +154,10 @@ namespace Examine
             yield return i;
         }
 
+        /// <summary>
+        /// Clones the value set
+        /// </summary>
+        /// <returns></returns>
         public ValueSet Clone() => new ValueSet(Id, Category, ItemType, Values);
     }
 }

--- a/src/Examine.Core/ValueSetValidationResult.cs
+++ b/src/Examine.Core/ValueSetValidationResult.cs
@@ -1,15 +1,25 @@
 namespace Examine
 {
+    /// <summary>
+    /// Represents a value set validation result
+    /// </summary>
     public struct ValueSetValidationResult
     {
+        /// <inheritdoc/>
         public ValueSetValidationResult(ValueSetValidationStatus status, ValueSet valueSet)
         {
             Status = status;
             ValueSet = valueSet;
         }
 
+        /// <summary>
+        /// The status of the validation
+        /// </summary>
         public ValueSetValidationStatus Status { get; }
 
+        /// <summary>
+        /// The value set of the validation
+        /// </summary>
         public ValueSet ValueSet { get; }
     }
 }

--- a/src/Examine.Core/ValueSetValidationStatus.cs
+++ b/src/Examine.Core/ValueSetValidationStatus.cs
@@ -1,5 +1,8 @@
-﻿namespace Examine
+namespace Examine
 {
+    /// <summary>
+    /// Represents a value sets validation status
+    /// </summary>
     public enum ValueSetValidationStatus
     {
         /// <summary>

--- a/src/Examine.Host/AspNetCoreApplicationIdentifier.cs
+++ b/src/Examine.Host/AspNetCoreApplicationIdentifier.cs
@@ -4,11 +4,16 @@ using Microsoft.AspNetCore.DataProtection;
 
 namespace Examine
 {
-
+    /// <inheritdoc/>
     public class AspNetCoreApplicationIdentifier : IApplicationIdentifier
     {
         private readonly IServiceProvider _services;
+
+        /// <inheritdoc/>
         public AspNetCoreApplicationIdentifier(IServiceProvider services) => _services = services;
+
+
+        /// <inheritdoc/>
         public string GetApplicationUniqueIdentifier() => _services.GetApplicationUniqueIdentifier();
     }
 }

--- a/src/Examine.Host/CurrentEnvironmentApplicationRoot.cs
+++ b/src/Examine.Host/CurrentEnvironmentApplicationRoot.cs
@@ -3,8 +3,10 @@ using System.IO;
 
 namespace Examine
 {
+    /// <inheritdoc/>
     public class CurrentEnvironmentApplicationRoot : IApplicationRoot
     {
+        /// <inheritdoc/>
         public DirectoryInfo ApplicationRoot { get; } = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "Examine"));
     }
 }

--- a/src/Examine.Host/Examine.csproj
+++ b/src/Examine.Host/Examine.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Description>A Lucene.Net search and indexing implementation for Examine</Description>
     <PackageTags>examine lucene lucene.net lucenenet search index</PackageTags>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examine.Host/ServicesCollectionExtensions.cs
+++ b/src/Examine.Host/ServicesCollectionExtensions.cs
@@ -14,6 +14,9 @@ using Microsoft.Extensions.Options;
 
 namespace Examine
 {
+    /// <summary>
+    /// Extensions for <see cref="IServiceCollection"/>
+    /// </summary>
     public static class ServicesCollectionExtensions
     {
         /// <summary>
@@ -142,6 +145,7 @@ namespace Examine
         /// Adds the Examine core services
         /// </summary>
         /// <param name="services"></param>
+        /// <param name="appRootDirectory"></param>
         /// <returns></returns>
         public static IServiceCollection AddExamine(this IServiceCollection services, DirectoryInfo appRootDirectory = null)
         {

--- a/src/Examine.Lucene/Analyzers/CultureInvariantStandardAnalyzer.cs
+++ b/src/Examine.Lucene/Analyzers/CultureInvariantStandardAnalyzer.cs
@@ -18,17 +18,20 @@ namespace Examine.Lucene.Analyzers
         private readonly bool _caseInsensitive;
         private readonly bool _ignoreLanguageAccents;
 
+        /// <inheritdoc/>
         public CultureInvariantStandardAnalyzer(CharArraySet stopWords)
             : this(stopWords, true, true)
         {
             
         }
 
+        /// <inheritdoc/>
         public CultureInvariantStandardAnalyzer()
             : this(StandardAnalyzer.STOP_WORDS_SET)
         {
         }
 
+        /// <inheritdoc/>
         public CultureInvariantStandardAnalyzer(CharArraySet stopWords, bool caseInsensitive, bool ignoreLanguageAccents)
         {
             _stopWordsSet = stopWords;
@@ -36,6 +39,7 @@ namespace Examine.Lucene.Analyzers
             _ignoreLanguageAccents = ignoreLanguageAccents;
         }
 
+        /// <inheritdoc/>
         protected override TokenStreamComponents CreateComponents(
             string fieldName,
             TextReader reader)
@@ -62,6 +66,9 @@ namespace Examine.Lucene.Analyzers
             return new TokenStreamComponents(tokenizer, result);
         }
 
+        /// <summary>
+        /// Set the max allowed token length. Any token longer than this is skipped
+        /// </summary>
         public int MaxTokenLength { set; get; } = byte.MaxValue;
 
     }

--- a/src/Examine.Lucene/Analyzers/CultureInvariantWhitespaceAnalyzer.cs
+++ b/src/Examine.Lucene/Analyzers/CultureInvariantWhitespaceAnalyzer.cs
@@ -19,16 +19,19 @@ namespace Examine.Lucene.Analyzers
         private readonly bool _caseInsensitive;
         private readonly bool _ignoreLanguageAccents;
 
+        /// <inheritdoc/>
         public CultureInvariantWhitespaceAnalyzer() : this(true, true)
         {
         }
 
+        /// <inheritdoc/>
         public CultureInvariantWhitespaceAnalyzer(bool caseInsensitive, bool ignoreLanguageAccents)
         {
             _caseInsensitive = caseInsensitive;
             _ignoreLanguageAccents = ignoreLanguageAccents;
         }
 
+        /// <inheritdoc/>
         protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
         {
             Tokenizer tokenizer = new LetterOrDigitTokenizer(reader);

--- a/src/Examine.Lucene/Analyzers/EmailAddressAnalyzer.cs
+++ b/src/Examine.Lucene/Analyzers/EmailAddressAnalyzer.cs
@@ -10,6 +10,7 @@ namespace Examine.Lucene.Analyzers
     /// </summary>
     public class EmailAddressAnalyzer : Analyzer
     {
+        /// <inheritdoc/>
         protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
         {
             Tokenizer tokenizer = new EmailAddressTokenizer(reader);

--- a/src/Examine.Lucene/Analyzers/PatternAnalyzer.cs
+++ b/src/Examine.Lucene/Analyzers/PatternAnalyzer.cs
@@ -32,6 +32,7 @@ namespace Examine.Lucene.Analyzers
             _pattern = new Regex(format);
         }
 
+        /// <inheritdoc/>
         protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
         {
             Tokenizer tokenizer = new PatternTokenizer(reader, _pattern, _regexGroup);

--- a/src/Examine.Lucene/DelegateFieldValueTypeFactory.cs
+++ b/src/Examine.Lucene/DelegateFieldValueTypeFactory.cs
@@ -11,8 +11,10 @@ namespace Examine.Lucene
     {
         private readonly Func<string, IIndexFieldValueType> _factory;
 
+        /// <inheritdoc/>
         public DelegateFieldValueTypeFactory(Func<string, IIndexFieldValueType> factory) => _factory = factory;
 
+        /// <inheritdoc/>
         public IIndexFieldValueType Create(string fieldName) => _factory(fieldName);
     }
 }

--- a/src/Examine.Lucene/Directories/DefaultLockFactory.cs
+++ b/src/Examine.Lucene/Directories/DefaultLockFactory.cs
@@ -1,10 +1,12 @@
-﻿using System.IO;
+using System.IO;
 using Lucene.Net.Store;
 
 namespace Examine.Lucene.Directories
 {
+    /// <inheritdoc/>
     public class DefaultLockFactory : ILockFactory
     {
+        /// <inheritdoc/>
         public LockFactory GetLockFactory(DirectoryInfo directory)
         {
             var nativeFsLockFactory = new NativeFSLockFactory(directory)

--- a/src/Examine.Lucene/Directories/DirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/DirectoryFactory.cs
@@ -9,8 +9,10 @@ namespace Examine.Lucene.Directories
     {
         private readonly Func<string, Directory> _factory;
 
+        /// <inheritdoc/>
         public GenericDirectoryFactory(Func<string, Directory> factory) => _factory = factory;
 
+        /// <inheritdoc/>
         protected override Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock)
         {
             Directory dir = _factory(luceneIndex.Name);

--- a/src/Examine.Lucene/Directories/DirectoryFactoryBase.cs
+++ b/src/Examine.Lucene/Directories/DirectoryFactoryBase.cs
@@ -4,6 +4,7 @@ using Directory = Lucene.Net.Store.Directory;
 
 namespace Examine.Lucene.Directories
 {
+    /// <inheritdoc/>
     public abstract class DirectoryFactoryBase : IDirectoryFactory
     {
         private readonly ConcurrentDictionary<string, Directory> _createdDirectories = new ConcurrentDictionary<string, Directory>();
@@ -14,8 +15,10 @@ namespace Examine.Lucene.Directories
                 luceneIndex.Name,
                 s => CreateDirectory(luceneIndex, forceUnlock));
 
+        /// <inheritdoc/>
         protected abstract Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock);
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -32,6 +35,7 @@ namespace Examine.Lucene.Directories
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs
@@ -10,14 +10,19 @@ namespace Examine.Lucene.Directories
     {
         private readonly DirectoryInfo _baseDir;
 
+        /// <inheritdoc/>
         public FileSystemDirectoryFactory(DirectoryInfo baseDir, ILockFactory lockFactory)
         {
             _baseDir = baseDir;
             LockFactory = lockFactory;
         }
 
+        /// <summary>
+        /// The factory for creating locks
+        /// </summary>
         public ILockFactory LockFactory { get; }
 
+        /// <inheritdoc/>
         protected override Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock)
         {
             var path = Path.Combine(_baseDir.FullName, luceneIndex.Name);

--- a/src/Examine.Lucene/Directories/IDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/IDirectoryFactory.cs
@@ -5,7 +5,7 @@ using Directory = Lucene.Net.Store.Directory;
 namespace Examine.Lucene.Directories
 {
     /// <summary>
-    /// Creates a Lucene <see cref="Lucene.Net.Store.Directory"/> for an index
+    /// Creates a Lucene <see cref="Directory"/> for an index
     /// </summary>
     /// <remarks>
     /// The directory created must only be created ONCE per index and disposed when the factory is disposed.

--- a/src/Examine.Lucene/Directories/ILockFactory.cs
+++ b/src/Examine.Lucene/Directories/ILockFactory.cs
@@ -1,10 +1,18 @@
-﻿using System.IO;
+using System.IO;
 using Lucene.Net.Store;
 
 namespace Examine.Lucene.Directories
 {
+    /// <summary>
+    /// A factory for creating lock files
+    /// </summary>
     public interface ILockFactory
     {
+        /// <summary>
+        /// Gets the lock factory
+        /// </summary>
+        /// <param name="directory"></param>
+        /// <returns></returns>
         LockFactory GetLockFactory(DirectoryInfo directory);
     }
 }

--- a/src/Examine.Lucene/Directories/MultiIndexLockFactory.cs
+++ b/src/Examine.Lucene/Directories/MultiIndexLockFactory.cs
@@ -14,7 +14,8 @@ namespace Examine.Lucene.Directories
         private readonly LockFactory _child;
 
         private static readonly object Locker = new object();
-        
+
+        /// <inheritdoc/>
         public MultiIndexLockFactory(Directory master, Directory child)
         {
             if (master == null) throw new ArgumentNullException("master");
@@ -22,7 +23,8 @@ namespace Examine.Lucene.Directories
             _master = master.LockFactory;
             _child = child.LockFactory;
         }
-        
+
+        /// <inheritdoc/>
         public MultiIndexLockFactory(LockFactory master, LockFactory child)
         {
             if (master == null) throw new ArgumentNullException("master");
@@ -34,7 +36,7 @@ namespace Examine.Lucene.Directories
             }
         }
 
-        
+        /// <inheritdoc/>
         public override Lock MakeLock(string lockName)
         {
             lock (Locker)
@@ -43,7 +45,7 @@ namespace Examine.Lucene.Directories
             }
         }
 
-        
+        /// <inheritdoc/>
         public override void ClearLock(string lockName)
         {
             lock (Locker)

--- a/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs
@@ -26,6 +26,7 @@ namespace Examine.Lucene.Directories
         private readonly ILoggerFactory _loggerFactory;
         private ExamineReplicator _replicator;
 
+        /// <inheritdoc/>
         public SyncedFileSystemDirectoryFactory(
             DirectoryInfo localDir,
             DirectoryInfo mainDir,
@@ -37,6 +38,7 @@ namespace Examine.Lucene.Directories
             _loggerFactory = loggerFactory;
         }
 
+        /// <inheritdoc/>
         protected override Directory CreateDirectory(LuceneIndex luceneIndex, bool forceUnlock)
         {
             var path = Path.Combine(_localDir.FullName, luceneIndex.Name);
@@ -91,6 +93,7 @@ namespace Examine.Lucene.Directories
             return localLuceneDir;
         }
 
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/src/Examine.Lucene/Directories/TempEnvFileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/TempEnvFileSystemDirectoryFactory.cs
@@ -12,6 +12,7 @@ namespace Examine.Lucene.Directories
     /// </remarks>
     public class TempEnvFileSystemDirectoryFactory : FileSystemDirectoryFactory
     {
+        /// <inheritdoc/>
         public TempEnvFileSystemDirectoryFactory(
             IApplicationIdentifier applicationIdentifier,
             ILockFactory lockFactory)
@@ -19,6 +20,11 @@ namespace Examine.Lucene.Directories
         {
         }
 
+        /// <summary>
+        /// Gets a temp path for examine indexes
+        /// </summary>
+        /// <param name="applicationIdentifier"></param>
+        /// <returns></returns>
         public static string GetTempPath(IApplicationIdentifier applicationIdentifier)
         {
             var appDomainHash = applicationIdentifier.GetApplicationUniqueIdentifier().GenerateHash();

--- a/src/Examine.Lucene/Examine.Lucene.csproj
+++ b/src/Examine.Lucene/Examine.Lucene.csproj
@@ -4,6 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>A Lucene.Net search and indexing implementation for Examine</Description>
     <PackageTags>examine lucene lucene.net lucenenet search index</PackageTags>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="AspExamineManager.cs.bak" />

--- a/src/Examine.Lucene/ExamineReplicator.cs
+++ b/src/Examine.Lucene/ExamineReplicator.cs
@@ -26,6 +26,7 @@ namespace Examine.Lucene
         private bool _started = false;
         private readonly ILogger<ExamineReplicator> _logger;
 
+        /// <inheritdoc/>
         public ExamineReplicator(
             ILoggerFactory loggerFactory,
             LuceneIndex sourceIndex,
@@ -89,6 +90,11 @@ namespace Examine.Lucene
             _localReplicationClient.UpdateNow();
         }
 
+        /// <summary>
+        /// Starts index replication
+        /// </summary>
+        /// <param name="milliseconds"></param>
+        /// <exception cref="InvalidOperationException"></exception>
         public void StartIndexReplicationOnSchedule(int milliseconds)
         {
             lock (_locker)
@@ -130,6 +136,7 @@ namespace Examine.Lucene
             _replicator.Publish(rev);
         }
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -144,6 +151,7 @@ namespace Examine.Lucene
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/src/Examine.Lucene/FacetExtensions.cs
+++ b/src/Examine.Lucene/FacetExtensions.cs
@@ -5,6 +5,9 @@ using Lucene.Net.Facet.Range;
 
 namespace Examine.Lucene
 {
+    /// <summary>
+    /// Extensions related to faceting
+    /// </summary>
     public static class FacetExtensions
     {
         /// <summary>

--- a/src/Examine.Lucene/FieldValueTypeCollection.cs
+++ b/src/Examine.Lucene/FieldValueTypeCollection.cs
@@ -17,7 +17,7 @@ namespace Examine.Lucene
         /// <summary>
         /// Create a <see cref="FieldValueTypeCollection"/>
         /// </summary>
-        /// <param name="analyzer">The default <see cref="Analyzer"/> to use for the resulting <see cref="PerFieldAnalyzerWrapper"/> used for indexing</param>
+        /// <param name="defaultAnalyzer">The default <see cref="Analyzer"/> to use for the resulting <see cref="PerFieldAnalyzerWrapper"/> used for indexing</param>
         /// <param name="valueTypeFactories">List of value type factories to initialize the collection with</param>
         /// <param name="fieldDefinitionCollection"></param>
         public FieldValueTypeCollection(

--- a/src/Examine.Lucene/IFieldValueTypeFactory.cs
+++ b/src/Examine.Lucene/IFieldValueTypeFactory.cs
@@ -1,4 +1,4 @@
-﻿using Examine.Lucene.Indexing;
+using Examine.Lucene.Indexing;
 
 namespace Examine.Lucene
 {
@@ -7,6 +7,11 @@ namespace Examine.Lucene
     /// </summary>
     public interface IFieldValueTypeFactory
     {
+        /// <summary>
+        /// Creates a <see cref="IIndexFieldValueType"/> for a field name
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <returns></returns>
         IIndexFieldValueType Create(string fieldName);
     }
 }

--- a/src/Examine.Lucene/Indexing/DateTimeType.cs
+++ b/src/Examine.Lucene/Indexing/DateTimeType.cs
@@ -88,6 +88,7 @@ namespace Examine.Lucene.Indexing
                 upper != null ? DateToLong(upper.Value) : (long?)null, lowerInclusive, upperInclusive);
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field)
             => field.ExtractFacets(facetExtractionContext);
     }

--- a/src/Examine.Lucene/Indexing/DateTimeType.cs
+++ b/src/Examine.Lucene/Indexing/DateTimeType.cs
@@ -11,9 +11,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
-
+    /// <summary>
+    /// Represents a DateTime <see cref="IndexFieldRangeValueType{T}"/>
+    /// </summary>
     public class DateTimeType : IndexFieldRangeValueType<DateTime>, IIndexFacetValueType
     {
+        /// <summary>
+        /// Specifies date granularity
+        /// </summary>
         public DateResolution Resolution { get; }
 
         private readonly bool _isFacetable;
@@ -23,6 +28,7 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => FieldName;
 
+        /// <inheritdoc/>
         public DateTimeType(string fieldName, ILoggerFactory logger, DateResolution resolution, bool store, bool isFacetable)
             : base(fieldName, logger, store)
         {
@@ -30,6 +36,7 @@ namespace Examine.Lucene.Indexing
             _isFacetable = isFacetable;
         }
 
+        /// <inheritdoc/>
         public DateTimeType(string fieldName, ILoggerFactory logger, DateResolution resolution, bool store = true)
             : base(fieldName, logger, store)
         {
@@ -37,6 +44,7 @@ namespace Examine.Lucene.Indexing
             _isFacetable = false;
         }
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (!TryConvert(value, out DateTime parsedVal))
@@ -63,6 +71,7 @@ namespace Examine.Lucene.Indexing
             return DateTools.Round(date, Resolution).Ticks;
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(string query)
         {
             if (!TryConvert(query, out DateTime parsedVal))
@@ -71,6 +80,7 @@ namespace Examine.Lucene.Indexing
             return GetQuery(parsedVal, parsedVal);
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(DateTime? lower, DateTime? upper, bool lowerInclusive = true, bool upperInclusive = true)
         {
             return NumericRangeQuery.NewInt64Range(FieldName,

--- a/src/Examine.Lucene/Indexing/DoubleType.cs
+++ b/src/Examine.Lucene/Indexing/DoubleType.cs
@@ -10,16 +10,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <summary>
+    /// Represents a Double <see cref="IndexFieldRangeValueType{T}"/>
+    /// </summary>
     public class DoubleType : IndexFieldRangeValueType<double>, IIndexFacetValueType
     {
         private readonly bool _isFacetable;
 
+        /// <inheritdoc/>
         public DoubleType(string fieldName, ILoggerFactory logger, bool store, bool isFacetable)
             : base(fieldName, logger, store)
         {
             _isFacetable = isFacetable;
         }
 
+        /// <inheritdoc/>
         public DoubleType(string fieldName, ILoggerFactory logger, bool store = true)
             : base(fieldName, logger, store)
         {
@@ -31,6 +36,7 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => FieldName;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (!TryConvert(value, out double parsedVal))
@@ -45,11 +51,13 @@ namespace Examine.Lucene.Indexing
             }
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(string query)
         {
             return !TryConvert(query, out double parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(double? lower, double? upper, bool lowerInclusive = true, bool upperInclusive = true)
         {
             return NumericRangeQuery.NewDoubleRange(FieldName,

--- a/src/Examine.Lucene/Indexing/DoubleType.cs
+++ b/src/Examine.Lucene/Indexing/DoubleType.cs
@@ -64,6 +64,8 @@ namespace Examine.Lucene.Indexing
                 lower ?? double.MinValue,
                 upper ?? double.MaxValue, lowerInclusive, upperInclusive);
         }
+
+        /// <inheritdoc/>
         public virtual IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field)
             => field.ExtractFacets(facetExtractionContext);
     }

--- a/src/Examine.Lucene/Indexing/FullTextType.cs
+++ b/src/Examine.Lucene/Indexing/FullTextType.cs
@@ -34,10 +34,12 @@ namespace Examine.Lucene.Indexing
         /// Constructor
         /// </summary>
         /// <param name="fieldName"></param>
+        /// <param name="logger"></param>
+        /// <param name="sortable"></param>
+        /// <param name="isFacetable"></param>
         /// <param name="analyzer">
         /// Defaults to <see cref="CultureInvariantStandardAnalyzer"/>
         /// </param>
-        /// <param name="sortable"></param>
         public FullTextType(string fieldName, ILoggerFactory logger, bool sortable = false, bool isFacetable = false, Analyzer analyzer = null)
             : base(fieldName, logger, true)
         {
@@ -178,6 +180,7 @@ namespace Examine.Lucene.Indexing
             return GenerateQuery(FieldName, query, _analyzer);
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field)
             => field.ExtractFacets(facetExtractionContext);
     }

--- a/src/Examine.Lucene/Indexing/FullTextType.cs
+++ b/src/Examine.Lucene/Indexing/FullTextType.cs
@@ -50,6 +50,7 @@ namespace Examine.Lucene.Indexing
         /// Constructor
         /// </summary>
         /// <param name="fieldName"></param>
+        /// <param name="logger"></param>
         /// <param name="analyzer">
         /// Defaults to <see cref="CultureInvariantStandardAnalyzer"/>
         /// </param>
@@ -67,8 +68,10 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => _sortable ? ExamineFieldNames.SortedFieldNamePrefix + FieldName : null;
 
+        /// <inheritdoc/>
         public override Analyzer Analyzer => _analyzer;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (TryConvert<string>(value, out var str))
@@ -91,6 +94,13 @@ namespace Examine.Lucene.Indexing
             }
         }
 
+        /// <summary>
+        /// Generates a full text query
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <param name="query"></param>
+        /// <param name="analyzer"></param>
+        /// <returns></returns>
         public static Query GenerateQuery(string fieldName, string query, Analyzer analyzer)
         {
             if (query == null)
@@ -162,7 +172,6 @@ namespace Examine.Lucene.Indexing
         /// Builds a full text search query
         /// </summary>
         /// <param name="query"></param>
-        /// 
         /// <returns></returns>
         public override Query GetQuery(string query)
         {

--- a/src/Examine.Lucene/Indexing/GenericAnalyzerFieldValueType.cs
+++ b/src/Examine.Lucene/Indexing/GenericAnalyzerFieldValueType.cs
@@ -15,6 +15,7 @@ namespace Examine.Lucene.Indexing
         private readonly Analyzer _analyzer;
         private readonly bool _sortable;
 
+        /// <inheritdoc/>
         public GenericAnalyzerFieldValueType(string fieldName, ILoggerFactory logger, Analyzer analyzer, bool sortable = false)
             : base(fieldName, logger, true)
         {
@@ -27,8 +28,10 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => _sortable ? ExamineFieldNames.SortedFieldNamePrefix + FieldName : null;
 
+        /// <inheritdoc/>
         public override Analyzer Analyzer => _analyzer;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (TryConvert<string>(value, out var str))

--- a/src/Examine.Lucene/Indexing/IIndexFacetValueType.cs
+++ b/src/Examine.Lucene/Indexing/IIndexFacetValueType.cs
@@ -4,13 +4,15 @@ using Examine.Search;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <summary>
+    /// Represents a facet index value type
+    /// </summary>
     public interface IIndexFacetValueType
     {
         /// <summary>
         /// Extracts the facets from the field
         /// </summary>
-        /// <param name="facetsCollector"></param>
-        /// <param name="sortedSetReaderState"></param>
+        /// <param name="facetExtractionContext"></param>
         /// <param name="field"></param>
         /// <returns>A dictionary of facets for this field</returns>
         IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field);

--- a/src/Examine.Lucene/Indexing/IIndexFieldValueType.cs
+++ b/src/Examine.Lucene/Indexing/IIndexFieldValueType.cs
@@ -10,13 +10,20 @@ namespace Examine.Lucene.Indexing
     /// </summary>
     public interface IIndexFieldValueType
     {
+        /// <summary>
+        /// The field name
+        /// </summary>
         string FieldName { get; }
 
         /// <summary>
         /// Returns the sortable field name or null if the value isn't sortable
         /// </summary>
+        /// <remarks>By default it will not be sortable</remarks>
         string SortableFieldName { get; }
 
+        /// <summary>
+        /// Should the value be stored
+        /// </summary>
         bool Store { get; }
 
         /// <summary>
@@ -24,8 +31,18 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         Analyzer Analyzer { get; }
 
+        /// <summary>
+        /// Adds a value to the document
+        /// </summary>
+        /// <param name="doc"></param>
+        /// <param name="value"></param>
         void AddValue(Document doc, object value);
-        
+
+        /// <summary>
+        /// Gets a query as <see cref="Query"/>
+        /// </summary>
+        /// <param name="query"></param>
+        /// <returns></returns>
         Query GetQuery(string query);
 
         //IHighlighter GetHighlighter(Query query, Searcher searcher, FacetsLoader facetsLoader);

--- a/src/Examine.Lucene/Indexing/IIndexRangeValueType.cs
+++ b/src/Examine.Lucene/Indexing/IIndexRangeValueType.cs
@@ -1,4 +1,4 @@
-﻿using Lucene.Net.Search;
+using Lucene.Net.Search;
 
 namespace Examine.Lucene.Indexing
 {
@@ -7,6 +7,14 @@ namespace Examine.Lucene.Indexing
     /// </summary>
     public interface IIndexRangeValueType
     {
+        /// <summary>
+        /// Gets a query as <see cref="Query"/>
+        /// </summary>
+        /// <param name="lower"></param>
+        /// <param name="upper"></param>
+        /// <param name="lowerInclusive"></param>
+        /// <param name="upperInclusive"></param>
+        /// <returns></returns>
         Query GetQuery(string lower, string upper, bool lowerInclusive = true, bool upperInclusive = true);
     }
 
@@ -16,6 +24,14 @@ namespace Examine.Lucene.Indexing
     /// <typeparam name="T"></typeparam>
     public interface IIndexRangeValueType<T> where T : struct
     {
+        /// <summary>
+        /// Gets a query as <see cref="Query"/>
+        /// </summary>
+        /// <param name="lower"></param>
+        /// <param name="upper"></param>
+        /// <param name="lowerInclusive"></param>
+        /// <param name="upperInclusive"></param>
+        /// <returns></returns>
         Query GetQuery(T? lower, T? upper, bool lowerInclusive = true, bool upperInclusive = true);
     }
 }

--- a/src/Examine.Lucene/Indexing/IndexFieldRangeValueType.cs
+++ b/src/Examine.Lucene/Indexing/IndexFieldRangeValueType.cs
@@ -3,15 +3,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <summary>
+    /// Used for value range types when the type is known
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     public abstract class IndexFieldRangeValueType<T> : IndexFieldValueTypeBase, IIndexRangeValueType<T>, IIndexRangeValueType
          where T : struct
     {
+        /// <inheritdoc/>
         protected IndexFieldRangeValueType(string fieldName, ILoggerFactory logger, bool store = true) : base(fieldName, logger, store)
         {
         }
 
+        /// <inheritdoc/>
         public abstract Query GetQuery(T? lower, T? upper, bool lowerInclusive = true, bool upperInclusive = true);
 
+        /// <inheritdoc/>
         public Query GetQuery(string lower, string upper, bool lowerInclusive = true, bool upperInclusive = true)
         {
             var lowerParsed = TryConvert<T>(lower, out var lowerValue);

--- a/src/Examine.Lucene/Indexing/IndexFieldValueTypeBase.cs
+++ b/src/Examine.Lucene/Indexing/IndexFieldValueTypeBase.cs
@@ -8,15 +8,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <inheritdoc/>
     public abstract class IndexFieldValueTypeBase : IIndexFieldValueType
     {
+        /// <inheritdoc/>
         public string FieldName { get; }
 
-        //by default it will not be sortable
+        /// <inheritdoc/>
         public virtual string SortableFieldName => null;
 
+        /// <inheritdoc/>
         public bool Store { get; }
 
+        /// <inheritdoc/>
         protected IndexFieldValueTypeBase(string fieldName, ILoggerFactory loggerFactory, bool store = true)
         {
             FieldName = fieldName;
@@ -24,10 +28,15 @@ namespace Examine.Lucene.Indexing
             Store = store;
         }
 
+        /// <inheritdoc/>
         public virtual Analyzer Analyzer => null;
 
+        /// <summary>
+        /// The logger
+        /// </summary>
         public ILogger Logger { get; }
 
+        /// <inheritdoc/>
         public virtual void AddValue(Document doc, object value) => AddSingleValueInternal(doc, value);
 
         private void AddSingleValueInternal(Document doc, object value)
@@ -38,6 +47,11 @@ namespace Examine.Lucene.Indexing
             }
         }
 
+        /// <summary>
+        /// Adds a single value to the document
+        /// </summary>
+        /// <param name="doc"></param>
+        /// <param name="value"></param>
         protected abstract void AddSingleValue(Document doc, object value);
 
         /// <summary>

--- a/src/Examine.Lucene/Indexing/Int32Type.cs
+++ b/src/Examine.Lucene/Indexing/Int32Type.cs
@@ -10,16 +10,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <summary>
+    /// Represents a Int32 <see cref="IndexFieldRangeValueType{T}" />
+    /// </summary>
     public class Int32Type : IndexFieldRangeValueType<int>, IIndexFacetValueType
     {
         private readonly bool _isFacetable;
 
+        /// <inheritdoc/>
         public Int32Type(string fieldName, ILoggerFactory logger, bool store, bool isFacetable)
             : base(fieldName, logger, store)
         {
             _isFacetable = isFacetable;
         }
 
+        /// <inheritdoc/>
         public Int32Type(string fieldName, ILoggerFactory logger, bool store = true)
             : base(fieldName, logger, store)
         {
@@ -31,6 +36,7 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => FieldName;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (!TryConvert(value, out int parsedVal))
@@ -45,11 +51,13 @@ namespace Examine.Lucene.Indexing
             }
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(string query)
         {
             return !TryConvert(query, out int parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(int? lower, int? upper, bool lowerInclusive = true, bool upperInclusive = true)
         {
             return NumericRangeQuery.NewInt32Range(FieldName,

--- a/src/Examine.Lucene/Indexing/Int32Type.cs
+++ b/src/Examine.Lucene/Indexing/Int32Type.cs
@@ -65,6 +65,7 @@ namespace Examine.Lucene.Indexing
                 upper, lowerInclusive, upperInclusive);
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field)
             => field.ExtractFacets(facetExtractionContext);
     }

--- a/src/Examine.Lucene/Indexing/Int64Type.cs
+++ b/src/Examine.Lucene/Indexing/Int64Type.cs
@@ -64,6 +64,8 @@ namespace Examine.Lucene.Indexing
                 lower,
                 upper, lowerInclusive, upperInclusive);
         }
+
+        /// <inheritdoc/>
         public virtual IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field)
             => field.ExtractFacets(facetExtractionContext);
     }

--- a/src/Examine.Lucene/Indexing/Int64Type.cs
+++ b/src/Examine.Lucene/Indexing/Int64Type.cs
@@ -10,16 +10,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <summary>
+    /// Represents a Int64 <see cref="IndexFieldRangeValueType{T}"/>
+    /// </summary>
     public class Int64Type : IndexFieldRangeValueType<long>, IIndexFacetValueType
     {
         private readonly bool _isFacetable;
 
+        /// <inheritdoc/>
         public Int64Type(string fieldName, ILoggerFactory logger, bool store, bool isFacetable)
             : base(fieldName, logger, store)
         {
             _isFacetable = isFacetable;
         }
 
+        /// <inheritdoc/>
         public Int64Type(string fieldName, ILoggerFactory logger, bool store = true)
             : base(fieldName, logger, store)
         {
@@ -31,6 +36,7 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => FieldName;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (!TryConvert(value, out long parsedVal))
@@ -45,11 +51,13 @@ namespace Examine.Lucene.Indexing
             }
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(string query)
         {
             return !TryConvert(query, out long parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(long? lower, long? upper, bool lowerInclusive = true, bool upperInclusive = true)
         {
             return NumericRangeQuery.NewInt64Range(FieldName,

--- a/src/Examine.Lucene/Indexing/RawStringType.cs
+++ b/src/Examine.Lucene/Indexing/RawStringType.cs
@@ -18,13 +18,16 @@ namespace Examine.Lucene.Indexing
         /// Constructor
         /// </summary>
         /// <param name="fieldName"></param>
+        /// <param name="logger"></param>
         /// <param name="store"></param>
         public RawStringType(string fieldName, ILoggerFactory logger, bool store = true)
             : base(fieldName, logger, store)
             => _analyzer = new KeywordAnalyzer();
 
+        /// <inheritdoc/>
         public override Analyzer Analyzer => _analyzer;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             switch (value)

--- a/src/Examine.Lucene/Indexing/SingleType.cs
+++ b/src/Examine.Lucene/Indexing/SingleType.cs
@@ -10,16 +10,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Examine.Lucene.Indexing
 {
+    /// <summary>
+    /// Represents a float/single <see cref="IndexFieldRangeValueType{T}"/>
+    /// </summary>
     public class SingleType : IndexFieldRangeValueType<float>, IIndexFacetValueType
     {
         private readonly bool _isFacetable;
 
+        /// <inheritdoc/>
         public SingleType(string fieldName, ILoggerFactory logger, bool store, bool isFacetable)
             : base(fieldName, logger, store)
         {
             _isFacetable = isFacetable;
         }
 
+        /// <inheritdoc/>
         public SingleType(string fieldName, ILoggerFactory logger, bool store = true)
             : base(fieldName, logger, store)
         {
@@ -31,6 +36,7 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         public override string SortableFieldName => FieldName;
 
+        /// <inheritdoc/>
         protected override void AddSingleValue(Document doc, object value)
         {
             if (!TryConvert(value, out float parsedVal))
@@ -45,11 +51,13 @@ namespace Examine.Lucene.Indexing
             }
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(string query)
         {
             return !TryConvert(query, out float parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }
 
+        /// <inheritdoc/>
         public override Query GetQuery(float? lower, float? upper, bool lowerInclusive = true, bool upperInclusive = true)
         {
             return NumericRangeQuery.NewDoubleRange(FieldName,

--- a/src/Examine.Lucene/Indexing/SingleType.cs
+++ b/src/Examine.Lucene/Indexing/SingleType.cs
@@ -65,6 +65,7 @@ namespace Examine.Lucene.Indexing
                 upper ?? float.MaxValue, lowerInclusive, upperInclusive);
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext, IFacetField field)
             => field.ExtractFacets(facetExtractionContext);
     }

--- a/src/Examine.Lucene/LoggingReplicationClient.cs
+++ b/src/Examine.Lucene/LoggingReplicationClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Lucene.Net.Replicator;
 using Microsoft.Extensions.Logging;
 
@@ -11,6 +11,7 @@ namespace Examine.Lucene
     {
         private readonly ILogger<LoggingReplicationClient> _logger;
 
+        /// <inheritdoc/>
         public LoggingReplicationClient(
             ILogger<LoggingReplicationClient> logger,
             IReplicator replicator,
@@ -22,6 +23,7 @@ namespace Examine.Lucene
             InfoStream = new CustomLoggingInfoStream(logger);
         }
 
+        /// <inheritdoc/>
         protected override void HandleUpdateException(Exception exception)
             => _logger.LogError(exception, "Index replication error occurred");
 

--- a/src/Examine.Lucene/LuceneDirectoryIndexOptions.cs
+++ b/src/Examine.Lucene/LuceneDirectoryIndexOptions.cs
@@ -4,6 +4,9 @@ using Lucene.Net.Store;
 
 namespace Examine.Lucene
 {
+    /// <summary>
+    /// Represents options for the lucene index
+    /// </summary>
     public class LuceneDirectoryIndexOptions : LuceneIndexOptions
     {
         /// <summary>

--- a/src/Examine.Lucene/LuceneIndexOptions.cs
+++ b/src/Examine.Lucene/LuceneIndexOptions.cs
@@ -8,12 +8,19 @@ using Lucene.Net.Index;
 
 namespace Examine.Lucene
 {
-
+    /// <summary>
+    /// Represents options for a lucene index
+    /// </summary>
     public class LuceneIndexOptions : IndexOptions
     {
-
+        /// <summary>
+        /// THe index deletion policy
+        /// </summary>
         public IndexDeletionPolicy IndexDeletionPolicy { get; set; }
 
+        /// <summary>
+        /// The analyzer used in the index
+        /// </summary>
         public Analyzer Analyzer { get; set; }
 
         /// <summary>

--- a/src/Examine.Lucene/LuceneInfo.cs
+++ b/src/Examine.Lucene/LuceneInfo.cs
@@ -2,8 +2,14 @@ using Lucene.Net.Util;
 
 namespace Examine
 {
+    /// <summary>
+    /// Information about lucene
+    /// </summary>
     public static class LuceneInfo
     {
+        /// <summary>
+        /// Gets the current lucene version
+        /// </summary>
         public static LuceneVersion CurrentVersion { get; } = LuceneVersion.LUCENE_48;
     }
 }

--- a/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
@@ -33,6 +33,10 @@ namespace Examine.Lucene.Providers
         /// </summary>
         public Analyzer LuceneAnalyzer { get; }
 
+        /// <summary>
+        /// Gets the seach context
+        /// </summary>
+        /// <returns></returns>
         public abstract ISearchContext GetSearchContext();
 
         /// <inheritdoc />

--- a/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
@@ -19,6 +19,7 @@ namespace Examine.Lucene.Providers
         /// </summary>
         /// <param name="name"></param>
         /// <param name="analyzer"></param>
+        /// <param name="facetsConfig"></param>
         protected BaseLuceneSearcher(string name, Analyzer analyzer, FacetsConfig facetsConfig)
             : base(name)
         {

--- a/src/Examine.Lucene/Providers/ErrorCheckingScoringBooleanQueryRewrite.cs
+++ b/src/Examine.Lucene/Providers/ErrorCheckingScoringBooleanQueryRewrite.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
@@ -24,7 +24,7 @@ namespace Examine.Lucene.Providers
     [Serializable]
     public class ErrorCheckingScoringBooleanQueryRewrite : MultiTermQuery.RewriteMethod
     {
-        
+        /// <inheritdoc/>
         public override Query Rewrite(IndexReader reader, MultiTermQuery query)
         {
             //we'll try to use the SCORING_BOOLEAN_QUERY_REWRITE but this can result in TooManyClauses

--- a/src/Examine.Lucene/Providers/IndexThreadingMode.cs
+++ b/src/Examine.Lucene/Providers/IndexThreadingMode.cs
@@ -1,5 +1,8 @@
-﻿namespace Examine.Lucene.Providers
+namespace Examine.Lucene.Providers
 {
+    /// <summary>
+    /// Represents the threading mode of indexing documents
+    /// </summary>
     public enum IndexThreadingMode
     {
         /// <summary>

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -152,6 +152,9 @@ namespace Examine.Lucene.Providers
         /// </summary>
         public Analyzer DefaultAnalyzer { get; }
 
+        /// <summary>
+        /// Gets the field ananlyzer
+        /// </summary>
         public PerFieldAnalyzerWrapper FieldAnalyzer => _fieldAnalyzer
             ?? (_fieldAnalyzer =
                 (DefaultAnalyzer is PerFieldAnalyzerWrapper pfa)
@@ -159,6 +162,9 @@ namespace Examine.Lucene.Providers
                     : _fieldValueTypeCollection.Value.Analyzer);
 
 
+        /// <summary>
+        /// Not used, will be removed in future versions
+        /// </summary>
         [Obsolete("Not used, will be removed in future versions")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int CommitCount { get; protected internal set; }
@@ -183,6 +189,9 @@ namespace Examine.Lucene.Providers
         /// </summary>
         public event EventHandler<DocumentWritingEventArgs> DocumentWriting;
 
+        /// <summary>
+        /// Occurs when an index is commited
+        /// </summary>
         public event EventHandler IndexCommitted;
 
         #endregion
@@ -205,6 +214,10 @@ namespace Examine.Lucene.Providers
 
         }
 
+        /// <summary>
+        /// Called when a document in writing
+        /// </summary>
+        /// <param name="docArgs"></param>
         protected virtual void OnDocumentWriting(DocumentWritingEventArgs docArgs)
             => DocumentWriting?.Invoke(this, docArgs);
 
@@ -212,6 +225,7 @@ namespace Examine.Lucene.Providers
 
         #region Provider implementation
 
+        /// <inheritdoc/>
         protected override void PerformIndexItems(IEnumerable<ValueSet> values, Action<IndexOperationEventArgs> onComplete)
         {
             // need to lock, we don't want to issue any node writing if there's an index rebuild occuring
@@ -641,7 +655,6 @@ namespace Examine.Lucene.Providers
         /// Removes the specified term from the index
         /// </summary>
         /// <param name="indexTerm"></param>
-        /// <param name="iw"></param>
         /// <param name="performCommit"></param>
         /// <returns>Boolean if it successfully deleted the term, or there were on errors</returns>
         private bool DeleteFromIndex(Term indexTerm, bool performCommit = true)
@@ -681,7 +694,6 @@ namespace Examine.Lucene.Providers
         /// </summary>
         /// <param name="doc"></param>
         /// <param name="valueSet">The data to index.</param>
-        /// <param name="writer">The writer that will be used to update the Lucene index.</param>
         protected virtual void AddDocument(Document doc, ValueSet valueSet)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -1055,7 +1067,6 @@ namespace Examine.Lucene.Providers
         /// Deletes the item from the index either by id or by category
         /// </summary>
         /// <param name="op"></param>
-        /// <param name="iw"></param>
         /// <param name="performCommit"></param>
         private void ProcessDeleteQueueItem(IndexOperation op, bool performCommit = true)
         {
@@ -1214,8 +1225,10 @@ namespace Examine.Lucene.Providers
             protected override void DisposeResources() => _index.RunAsync = _orig;
         }
 
+        /// <inheritdoc/>
         public long GetDocumentCount() => IndexWriter.IndexWriter.NumDocs;
 
+        /// <inheritdoc/>
         public IEnumerable<string> GetFieldNames()
         {
             var writer = IndexWriter;
@@ -1248,6 +1261,7 @@ namespace Examine.Lucene.Providers
             return false;
         }
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -1313,6 +1327,7 @@ namespace Examine.Lucene.Providers
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose() => Dispose(disposing: true);
 
         void ReferenceManager.IRefreshListener.BeforeRefresh() { }

--- a/src/Examine.Lucene/Providers/LuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/LuceneSearcher.cs
@@ -23,6 +23,7 @@ namespace Examine.Lucene.Providers
         /// <param name="searcherManager"></param>
         /// <param name="analyzer"></param>
         /// <param name="fieldValueTypeCollection"></param>
+        /// <param name="facetsConfig"></param>
         public LuceneSearcher(string name, SearcherManager searcherManager, Analyzer analyzer, FieldValueTypeCollection fieldValueTypeCollection, FacetsConfig facetsConfig)
             : base(name, analyzer, facetsConfig)
         {

--- a/src/Examine.Lucene/Providers/LuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/LuceneSearcher.cs
@@ -20,7 +20,7 @@ namespace Examine.Lucene.Providers
         /// Constructor allowing for creating a NRT instance based on a given writer
         /// </summary>
         /// <param name="name"></param>
-        /// <param name="writer"></param>
+        /// <param name="searcherManager"></param>
         /// <param name="analyzer"></param>
         /// <param name="fieldValueTypeCollection"></param>
         public LuceneSearcher(string name, SearcherManager searcherManager, Analyzer analyzer, FieldValueTypeCollection fieldValueTypeCollection, FacetsConfig facetsConfig)
@@ -30,9 +30,11 @@ namespace Examine.Lucene.Providers
             _fieldValueTypeCollection = fieldValueTypeCollection;
         }
 
+        /// <inheritdoc/>
         public override ISearchContext GetSearchContext()
             => new SearchContext(_searcherManager, _fieldValueTypeCollection);
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -46,6 +48,7 @@ namespace Examine.Lucene.Providers
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/src/Examine.Lucene/Providers/MultiIndexSearcher.cs
+++ b/src/Examine.Lucene/Providers/MultiIndexSearcher.cs
@@ -47,9 +47,12 @@ namespace Examine.Lucene.Providers
         ///</summary>
         public IEnumerable<LuceneSearcher> Searchers => _searchers.Value.OfType<LuceneSearcher>();
 
-        // for tests
+        /// <summary>
+        /// Are the searchers initialized
+        /// </summary>
         public bool SearchersInitialized => _searchers.IsValueCreated;
 
+        /// <inheritdoc/>
         public override ISearchContext GetSearchContext()
             => new MultiSearchContext(Searchers.Select(s => s.GetSearchContext()).ToArray());
 

--- a/src/Examine.Lucene/Providers/ValueSetValidatorDelegate.cs
+++ b/src/Examine.Lucene/Providers/ValueSetValidatorDelegate.cs
@@ -9,9 +9,11 @@ namespace Examine.Lucene.Providers
     {
         private readonly Func<ValueSet, ValueSetValidationResult> _validator;
 
+        /// <inheritdoc/>
         public ValueSetValidatorDelegate(Func<ValueSet, ValueSetValidationResult> validator)
             => _validator = validator;
 
+        /// <inheritdoc/>
         public ValueSetValidationResult Validate(ValueSet valueSet)
             => _validator(valueSet);
     }

--- a/src/Examine.Lucene/ReaderStatus.cs
+++ b/src/Examine.Lucene/ReaderStatus.cs
@@ -1,9 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
 namespace Examine.Lucene
 {
-    public enum ReaderStatus { Current, Closed, NotCurrent }
+    /// <summary>
+    /// TODO: Is this enum used? (Found 0 references)
+    /// </summary>
+    public enum ReaderStatus {
+        /// <summary>
+        /// 
+        /// </summary>
+        Current,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Closed,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        NotCurrent
+    }
 }

--- a/src/Examine.Lucene/Search/CustomMultiFieldQueryParser.cs
+++ b/src/Examine.Lucene/Search/CustomMultiFieldQueryParser.cs
@@ -14,15 +14,26 @@ namespace Examine.Lucene.Search
     /// </summary>
     public class CustomMultiFieldQueryParser : MultiFieldQueryParser
     {
-
+        /// <inheritdoc/>
         public CustomMultiFieldQueryParser(LuceneVersion matchVersion, string[] fields, Analyzer analyzer)
             : base(matchVersion, fields, analyzer)
             => SearchableFields = fields;
 
         internal static QueryParser KeywordAnalyzerQueryParser { get; } = new QueryParser(LuceneInfo.CurrentVersion, string.Empty, new KeywordAnalyzer());
 
+        /// <summary>
+        /// Fields that are searchable by the query parser
+        /// </summary>
         public string[] SearchableFields { get; }
 
+        /// <summary>
+        /// Gets a fuzzy query
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="termStr"></param>
+        /// <param name="minSimilarity"></param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentException"></exception>
         public virtual Query GetFuzzyQueryInternal(string field, string termStr, float minSimilarity)
         {
             if (string.IsNullOrWhiteSpace(termStr))
@@ -38,6 +49,7 @@ namespace Examine.Lucene.Search
         /// <param name="part1"></param>
         /// <param name="part2"></param>
         /// <param name="startInclusive"></param>
+        /// <param name="endInclusive"></param>
         /// <returns></returns>
         /// <remarks>
         /// By Default the lucene query parser only deals with strings and the result is a TermRangeQuery, however for numerics it needs to be a
@@ -52,6 +64,13 @@ namespace Examine.Lucene.Search
             return base.GetRangeQuery(field, part1, part2, startInclusive, endInclusive);
         }
 
+        /// <summary>
+        /// Gets a wildcard query
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="termStr"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
         public virtual Query GetWildcardQueryInternal(string field, string termStr)
         {
             if (string.IsNullOrWhiteSpace(termStr))
@@ -75,6 +94,13 @@ namespace Examine.Lucene.Search
             return GetFieldQuery(field, queryText, slop);
         }
 
+        /// <summary>
+        /// Gets a query field
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="queryText"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
         public Query GetFieldQueryInternal(string field, string queryText)
         {
             if (string.IsNullOrWhiteSpace(queryText))

--- a/src/Examine.Lucene/Search/ExamineMultiFieldQueryParser.cs
+++ b/src/Examine.Lucene/Search/ExamineMultiFieldQueryParser.cs
@@ -12,6 +12,7 @@ namespace Examine.Lucene.Search
     {
         private readonly ISearchContext _searchContext;
 
+        /// <inheritdoc/>
         public ExamineMultiFieldQueryParser(ISearchContext searchContext, LuceneVersion matchVersion, Analyzer analyzer)
             : base(matchVersion, searchContext.SearchableFields, analyzer)
         {
@@ -24,7 +25,8 @@ namespace Examine.Lucene.Search
         /// <param name="field"></param>
         /// <param name="part1"></param>
         /// <param name="part2"></param>
-        /// <param name="inclusive"></param>
+        /// <param name="startInclusive"></param>
+        /// <param name="endInclusive"></param>
         /// <returns></returns>
         /// <remarks>
         /// By Default the lucene query parser only deals with strings and the result is a TermRangeQuery, however for numerics it needs to be a

--- a/src/Examine.Lucene/Search/FacetDoubleField.cs
+++ b/src/Examine.Lucene/Search/FacetDoubleField.cs
@@ -5,15 +5,26 @@ using System.Linq;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a double facet field
+    /// </summary>
     public readonly struct FacetDoubleField : IFacetField
     {
+        /// <summary>
+        /// The double ranges for the field
+        /// </summary>
         public Examine.Search.DoubleRange[] DoubleRanges { get; }
 
+        /// <inheritdoc/>
         public string Field { get; }
 
+        /// <inheritdoc/>
         public string FacetField { get; }
+
+        /// <inheritdoc/>
         public bool IsTaxonomyIndexed { get; }
 
+        /// <inheritdoc/>
         public FacetDoubleField(string field, Examine.Search.DoubleRange[] doubleRanges, string facetField, bool isTaxonomyIndexed = false)
         {
             Field = field;
@@ -22,6 +33,7 @@ namespace Examine.Lucene.Search
             IsTaxonomyIndexed = isTaxonomyIndexed;
         }
 
+        /// <inheritdoc/>
         public IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext)
         {
             var doubleFacetCounts = new DoubleRangeFacetCounts(Field, facetExtractionContext.FacetsCollector, DoubleRanges.AsLuceneRange().ToArray());

--- a/src/Examine.Lucene/Search/FacetFloatField.cs
+++ b/src/Examine.Lucene/Search/FacetFloatField.cs
@@ -6,15 +6,26 @@ using Lucene.Net.Queries.Function.ValueSources;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a float facet field
+    /// </summary>
     public readonly struct FacetFloatField : IFacetField
     {
+        /// <summary>
+        /// The float ranges for the field
+        /// </summary>
         public FloatRange[] FloatRanges { get; }
 
+        /// <inheritdoc/>
         public string Field { get; }
 
+        /// <inheritdoc/>
         public string FacetField { get; }
+
+        /// <inheritdoc/>
         public bool IsTaxonomyIndexed { get; }
 
+        /// <inheritdoc/>
         public FacetFloatField(string field, FloatRange[] floatRanges, string facetField, bool isTaxonomyIndexed = false)
         {
             Field = field;
@@ -23,6 +34,7 @@ namespace Examine.Lucene.Search
             IsTaxonomyIndexed = isTaxonomyIndexed;
         }
 
+        /// <inheritdoc/>
         public IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext)
         {
             var floatFacetCounts = new DoubleRangeFacetCounts(Field, new SingleFieldSource(Field), facetExtractionContext.FacetsCollector, FloatRanges.AsLuceneRange().ToArray());

--- a/src/Examine.Lucene/Search/FacetFullTextField.cs
+++ b/src/Examine.Lucene/Search/FacetFullTextField.cs
@@ -5,20 +5,36 @@ using Lucene.Net.Facet;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a full text facet field
+    /// </summary>
     public class FacetFullTextField : IFacetField
     {
+        /// <summary>
+        /// Maximum number of terms to return
+        /// </summary>
         public int MaxCount { get; internal set; }
 
+        /// <summary>
+        /// Filter values
+        /// </summary>
         public string[] Values { get; }
 
+        /// <inheritdoc/>
         public string Field { get; }
 
+        /// <inheritdoc/>
         public string FacetField { get; }
 
+        /// <summary>
+        /// Path hierachy
+        /// </summary>
         public string[] Path { get; internal set; }
 
+        /// <inheritdoc/>
         public bool IsTaxonomyIndexed { get; }
 
+        /// <inheritdoc/>
         public FacetFullTextField(string field, string[] values, string facetField, int maxCount = 10, string[] path = null, bool isTaxonomyIndexed = false)
         {
             Field = field;
@@ -29,6 +45,7 @@ namespace Examine.Lucene.Search
             IsTaxonomyIndexed = isTaxonomyIndexed;
         }
 
+        /// <inheritdoc/>
         public IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext)
         {
             Facets facetCounts = facetExtractionContext.GetFacetCounts(FacetField, false);

--- a/src/Examine.Lucene/Search/FacetLongField.cs
+++ b/src/Examine.Lucene/Search/FacetLongField.cs
@@ -7,15 +7,26 @@ using Lucene.Net.Facet.SortedSet;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a long facet field
+    /// </summary>
     public readonly struct FacetLongField : IFacetField
     {
+        /// <inheritdoc/>
         public string Field { get; }
 
+        /// <summary>
+        /// The long ranges
+        /// </summary>
         public Examine.Search.Int64Range[] LongRanges { get; }
 
+        /// <inheritdoc/>
         public string FacetField { get; }
+
+        /// <inheritdoc/>
         public bool IsTaxonomyIndexed { get; }
 
+        /// <inheritdoc/>
         public FacetLongField(string field, Examine.Search.Int64Range[] longRanges, string facetField, bool isTaxonomyIndexed = false)
         {
             Field = field;
@@ -24,6 +35,7 @@ namespace Examine.Lucene.Search
             IsTaxonomyIndexed = isTaxonomyIndexed;
         }
 
+        /// <inheritdoc/>
         public IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext)
         {
             var longFacetCounts = new Int64RangeFacetCounts(Field, facetExtractionContext.FacetsCollector, LongRanges.AsLuceneRange().ToArray());

--- a/src/Examine.Lucene/Search/FacetQueryField.cs
+++ b/src/Examine.Lucene/Search/FacetQueryField.cs
@@ -2,10 +2,14 @@ using Examine.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a default facet query field (FullText)
+    /// </summary>
     public class FacetQueryField : IFacetQueryField
     {
         private readonly FacetFullTextField _field;
 
+        /// <inheritdoc/>
         public FacetQueryField(FacetFullTextField field)
         {
             _field = field;

--- a/src/Examine.Lucene/Search/FacetQueryField.cs
+++ b/src/Examine.Lucene/Search/FacetQueryField.cs
@@ -23,6 +23,7 @@ namespace Examine.Lucene.Search
             return this;
         }
 
+        /// <inheritdoc/>
         public IFacetQueryField SetPath(params string[] path)
         {
             _field.Path = path;

--- a/src/Examine.Lucene/Search/IFacetField.cs
+++ b/src/Examine.Lucene/Search/IFacetField.cs
@@ -3,6 +3,9 @@ using Examine.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a base facet field
+    /// </summary>
     public interface IFacetField
     {
         /// <summary>
@@ -23,8 +26,7 @@ namespace Examine.Lucene.Search
         /// <summary>
         /// Extracts the facets from the field
         /// </summary>
-        /// <param name="facetsCollector"></param>
-        /// <param name="sortedSetReaderState"></param>
+        /// <param name="facetExtractionContext"></param>
         /// <returns>Returns the facets for this field</returns>
         IEnumerable<KeyValuePair<string, IFacetResult>> ExtractFacets(IFacetExtractionContext facetExtractionContext);
     }

--- a/src/Examine.Lucene/Search/ISearchContext.cs
+++ b/src/Examine.Lucene/Search/ISearchContext.cs
@@ -3,11 +3,27 @@ using Examine.Lucene.Indexing;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a search context
+    /// </summary>
     public interface ISearchContext
     {
+        /// <summary>
+        /// Gets the searcher of the context
+        /// </summary>
+        /// <returns></returns>
         ISearcherReference GetSearcher();
 
+        /// <summary>
+        /// The searchable fields of a search context
+        /// </summary>
         string[] SearchableFields { get; }
+
+        /// <summary>
+        /// Gets the field value type of a field name
+        /// </summary>
+        /// <param name="fieldName"></param>
+        /// <returns></returns>
         IIndexFieldValueType GetFieldValueType(string fieldName);
     }
 }

--- a/src/Examine.Lucene/Search/ISearcherReference.cs
+++ b/src/Examine.Lucene/Search/ISearcherReference.cs
@@ -1,11 +1,17 @@
-﻿using System;
+using System;
 using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
 {
-    // Dispose will release it from the manager
+    /// <summary>
+    /// Represents a searcher reference
+    /// </summary>
+    /// <remarks>Dispose will release it from the manager</remarks>
     public interface ISearcherReference : IDisposable
     {
+        /// <summary>
+        /// The index searcher
+        /// </summary>
         IndexSearcher IndexSearcher { get; }
     }
 }

--- a/src/Examine.Lucene/Search/LateBoundQuery.cs
+++ b/src/Examine.Lucene/Search/LateBoundQuery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
@@ -6,23 +6,33 @@ using Lucene.Net.Search.Similarities;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a late bound query
+    /// </summary>
     public class LateBoundQuery : Query
     {
         private readonly Func<Query> _factory;
 
         private Query _wrapped;
+
+        /// <summary>
+        /// The wrapped query
+        /// </summary>
         public Query Wrapped => _wrapped ?? (_wrapped = _factory());
 
+        /// <inheritdoc/>
         public LateBoundQuery(Func<Query> factory)
         {
             _factory = factory;
         }
 
+        /// <inheritdoc/>
         public override object Clone()
         {
             return Wrapped.Clone();
         }
 
+        /// <inheritdoc/>
         public override Weight CreateWeight(IndexSearcher searcher)
         {
             return Wrapped.CreateWeight(searcher);
@@ -49,16 +59,13 @@ namespace Examine.Lucene.Search
             set => Wrapped.Boost = value;
         }
 
-     
-
+        /// <inheritdoc/>
         public override Query Rewrite(IndexReader reader)
         {
             return Wrapped.Rewrite(reader);
         }
 
-  
-
-
+        /// <inheritdoc/>
         public override string ToString(string field)
         {
             return Wrapped.ToString(field);

--- a/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
@@ -14,7 +14,8 @@ namespace Examine.Lucene.Search
     public class LuceneBooleanOperation : LuceneBooleanOperationBase, IQueryExecutor
     {
         private readonly LuceneSearchQuery _search;
-        
+
+        /// <inheritdoc/>
         public LuceneBooleanOperation(LuceneSearchQuery search)
             : base(search)
         {
@@ -45,26 +46,33 @@ namespace Examine.Lucene.Search
 
         #endregion
 
+        /// <inheritdoc/>
         public override ISearchResults Execute(QueryOptions options = null) => _search.Execute(options);
 
         #region IOrdering
 
+        /// <inheritdoc/>
         public override IOrdering OrderBy(params SortableField[] fields) => _search.OrderBy(fields);
 
+        /// <inheritdoc/>
         public override IOrdering OrderByDescending(params SortableField[] fields) => _search.OrderByDescending(fields);
 
         #endregion
 
         #region Select Fields
 
+        /// <inheritdoc/>
         public override IOrdering SelectFields(ISet<string> fieldNames) => _search.SelectFieldsInternal(fieldNames);
 
+        /// <inheritdoc/>
         public override IOrdering SelectField(string fieldName) => _search.SelectFieldInternal(fieldName);
 
+        /// <inheritdoc/>
         public override IOrdering SelectAllFields() => _search.SelectAllFieldsInternal();
 
         #endregion
 
+        /// <inheritdoc/>
         public override string ToString() => _search.ToString();
 
         public override IQueryExecutor WithFacets(Action<IFacetOperations> facets)

--- a/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
@@ -75,6 +75,7 @@ namespace Examine.Lucene.Search
         /// <inheritdoc/>
         public override string ToString() => _search.ToString();
 
+        /// <inheritdoc/>
         public override IQueryExecutor WithFacets(Action<IFacetOperations> facets)
         {
             var luceneFacetOperation = new LuceneFacetOperation(_search);

--- a/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
@@ -136,6 +136,7 @@ namespace Examine.Lucene.Search
         /// <inheritdoc/>
         public abstract IOrdering SelectAllFields();
 
+        /// <inheritdoc/>
         public abstract IQueryExecutor WithFacets(Action<IFacetOperations> facets);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
@@ -5,30 +5,71 @@ using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents the base for a <see cref="LuceneBooleanOperation"/>
+    /// </summary>
     public abstract class LuceneBooleanOperationBase : IBooleanOperation, INestedBooleanOperation, IOrdering, IFaceting
     {
         private readonly LuceneSearchQueryBase _search;
 
+        /// <inheritdoc/>
         protected LuceneBooleanOperationBase(LuceneSearchQueryBase search)
         {
             _search = search;
         }
 
+        /// <inheritdoc/>
         public abstract IQuery And();
+
+        /// <inheritdoc/>
         public abstract IQuery Or();
+
+        /// <inheritdoc/>
         public abstract IQuery Not();
 
+        /// <summary>
+        /// Allows for adding more operations to a query using the and operator
+        /// </summary>
+        /// <param name="inner"></param>
+        /// <param name="defaultOp"></param>
+        /// <returns></returns>
         public IBooleanOperation And(Func<INestedQuery, INestedBooleanOperation> inner, BooleanOperation defaultOp = BooleanOperation.And) 
             => Op(inner, BooleanOperation.And, defaultOp);
 
+        /// <summary>
+        /// Allows for adding more operations to a query using the or operator
+        /// </summary>
+        /// <param name="inner"></param>
+        /// <param name="defaultOp"></param>
+        /// <returns></returns>
         public IBooleanOperation Or(Func<INestedQuery, INestedBooleanOperation> inner, BooleanOperation defaultOp = BooleanOperation.And) 
             => Op(inner, BooleanOperation.Or, defaultOp);
 
+        /// <summary>
+        /// Allows for adding more operations to a query using the and not operator
+        /// </summary>
+        /// <param name="inner"></param>
+        /// <param name="defaultOp"></param>
+        /// <returns></returns>
         public IBooleanOperation AndNot(Func<INestedQuery, INestedBooleanOperation> inner, BooleanOperation defaultOp = BooleanOperation.And) 
             => Op(inner, BooleanOperation.Not, defaultOp);
 
+        /// <summary>
+        /// Allows for adding more operations to a query using a nested and
+        /// </summary>
+        /// <returns></returns>
         protected abstract INestedQuery AndNested();
+
+        /// <summary>
+        /// Allows for adding more operations to a query using a nested or
+        /// </summary>
+        /// <returns></returns>
         protected abstract INestedQuery OrNested();
+
+        /// <summary>
+        /// Allows for adding more operations to a query iusing a nested not
+        /// </summary>
+        /// <returns></returns>
         protected abstract INestedQuery NotNested();
 
         INestedQuery INestedBooleanOperation.And() => AndNested();
@@ -44,6 +85,13 @@ namespace Examine.Lucene.Search
         INestedBooleanOperation INestedBooleanOperation.AndNot(Func<INestedQuery, INestedBooleanOperation> inner, BooleanOperation defaultOp)
             => Op(inner, BooleanOperation.Not, defaultOp);
 
+        /// <summary>
+        /// Used to add a operation
+        /// </summary>
+        /// <param name="inner"></param>
+        /// <param name="outerOp"></param>
+        /// <param name="defaultInnerOp"></param>
+        /// <returns></returns>
         protected internal LuceneBooleanOperationBase Op(
             Func<INestedQuery, INestedBooleanOperation> inner,
             BooleanOperation outerOp,
@@ -70,12 +118,22 @@ namespace Examine.Lucene.Search
             return _search.LuceneQuery(_search.Queries.Pop(), outerOp);
         }
 
+        /// <inheritdoc/>
         public abstract ISearchResults Execute(QueryOptions options = null);
+
+        /// <inheritdoc/>
         public abstract IOrdering OrderBy(params SortableField[] fields);
+
+        /// <inheritdoc/>
         public abstract IOrdering OrderByDescending(params SortableField[] fields);
 
+        /// <inheritdoc/>
         public abstract IOrdering SelectFields(ISet<string> fieldNames);
+
+        /// <inheritdoc/>
         public abstract IOrdering SelectField(string fieldName);
+
+        /// <inheritdoc/>
         public abstract IOrdering SelectAllFields();
 
         public abstract IQueryExecutor WithFacets(Action<IFacetOperations> facets);

--- a/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
@@ -1,43 +1,47 @@
 using Lucene.Net.Facet.SortedSet;
 using Lucene.Net.Facet;
 using System;
-using Examine.Lucene.Search;
 
-public class LuceneFacetExtractionContext : IFacetExtractionContext
+namespace Examine.Lucene.Search
 {
-
-    private SortedSetDocValuesReaderState _sortedSetReaderState = null;
-
-    public LuceneFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcherReference, FacetsConfig facetConfig)
+    /// <inheritdoc/>
+    public class LuceneFacetExtractionContext : IFacetExtractionContext
     {
-        FacetsCollector = facetsCollector;
-        FacetConfig = facetConfig;
-        SearcherReference = searcherReference;
-    }
 
-    /// <inheritdoc/>
-    public FacetsCollector FacetsCollector { get; }
+        private SortedSetDocValuesReaderState _sortedSetReaderState = null;
 
-    /// <inheritdoc/>
-    public FacetsConfig FacetConfig { get; }
-
-    /// <inheritdoc/>
-    public ISearcherReference SearcherReference { get; }
-
-    /// <inheritdoc/>
-    public virtual Facets GetFacetCounts(string facetIndexFieldName, bool isTaxonomyIndexed)
-    {
-        if (isTaxonomyIndexed)
+        /// <inheritdoc/>
+        public LuceneFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcherReference, FacetsConfig facetConfig)
         {
-            throw new NotSupportedException("Taxonomy Index not supported");
+            FacetsCollector = facetsCollector;
+            FacetConfig = facetConfig;
+            SearcherReference = searcherReference;
         }
-        else
+
+        /// <inheritdoc/>
+        public FacetsCollector FacetsCollector { get; }
+
+        /// <inheritdoc/>
+        public FacetsConfig FacetConfig { get; }
+
+        /// <inheritdoc/>
+        public ISearcherReference SearcherReference { get; }
+
+        /// <inheritdoc/>
+        public virtual Facets GetFacetCounts(string facetIndexFieldName, bool isTaxonomyIndexed)
         {
-            if (_sortedSetReaderState == null || !_sortedSetReaderState.Field.Equals(facetIndexFieldName))
+            if (isTaxonomyIndexed)
             {
-                _sortedSetReaderState = new DefaultSortedSetDocValuesReaderState(SearcherReference.IndexSearcher.IndexReader, facetIndexFieldName);
+                throw new NotSupportedException("Taxonomy Index not supported");
             }
-            return new SortedSetDocValuesFacetCounts(_sortedSetReaderState, FacetsCollector);
+            else
+            {
+                if (_sortedSetReaderState == null || !_sortedSetReaderState.Field.Equals(facetIndexFieldName))
+                {
+                    _sortedSetReaderState = new DefaultSortedSetDocValuesReaderState(SearcherReference.IndexSearcher.IndexReader, facetIndexFieldName);
+                }
+                return new SortedSetDocValuesFacetCounts(_sortedSetReaderState, FacetsCollector);
+            }
         }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneFacetOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetOperation.cs
@@ -16,23 +16,31 @@ namespace Examine.Lucene.Search
     {
         private readonly LuceneSearchQuery _search;
 
+        /// <inheritdoc/>
         public LuceneFacetOperation(LuceneSearchQuery search)
         {
             _search = search;
         }
 
+        /// <inheritdoc/>
         public ISearchResults Execute(QueryOptions options = null) => _search.Execute(options);
 
+        /// <inheritdoc/>
         public IFacetOperations Facet(string field, Action<IFacetQueryField> facetConfiguration = null) => _search.FacetInternal(field, facetConfiguration, Array.Empty<string>());
 
+        /// <inheritdoc/>
         public IFacetOperations Facet(string field, Action<IFacetQueryField> facetConfiguration = null, params string[] values) => _search.FacetInternal(field, facetConfiguration, values);
 
+        /// <inheritdoc/>
         public IFacetOperations Facet(string field, params DoubleRange[] doubleRanges) => _search.FacetInternal(field, doubleRanges);
 
+        /// <inheritdoc/>
         public IFacetOperations Facet(string field, params FloatRange[] floatRanges) => _search.FacetInternal(field, floatRanges);
 
+        /// <inheritdoc/>
         public IFacetOperations Facet(string field, params Int64Range[] longRanges) => _search.FacetInternal(field, longRanges);
 
+        /// <inheritdoc/>
         public override string ToString() => _search.ToString();
     }
 }

--- a/src/Examine.Lucene/Search/LuceneQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneQuery.cs
@@ -8,6 +8,9 @@ using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a lucene query
+    /// </summary>
     public class LuceneQuery : IQuery, INestedQuery
     {
         private readonly LuceneSearchQuery _search;
@@ -25,43 +28,59 @@ namespace Examine.Lucene.Search
             _occurrence = occurrence;
         }
 
+        /// <inheritdoc/>
         public IBooleanOperation Field<T>(string fieldName, T fieldValue) where T : struct
             => RangeQuery<T>(new[] { fieldName }, fieldValue, fieldValue);
 
+        /// <inheritdoc/>
         public IBooleanOperation Field(string fieldName, string fieldValue)
             => _search.FieldInternal(fieldName, new ExamineValue(Examineness.Explicit, fieldValue), _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation Field(string fieldName, IExamineValue fieldValue)
             => _search.FieldInternal(fieldName, fieldValue, _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params string[] query)
             => _search.GroupedAndInternal(fields.ToArray(), query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray(), _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params IExamineValue[] query)
             => _search.GroupedAndInternal(fields.ToArray(), query, _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedOr(IEnumerable<string> fields, params string[] query)
             => _search.GroupedOrInternal(fields.ToArray(), query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray(), _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedOr(IEnumerable<string> fields, params IExamineValue[] query)
             => _search.GroupedOrInternal(fields.ToArray(), query, _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedNot(IEnumerable<string> fields, params string[] query)
             => _search.GroupedNotInternal(fields.ToArray(), query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedNot(IEnumerable<string> fields, params IExamineValue[] query)
             => _search.GroupedNotInternal(fields.ToArray(), query);
 
+        /// <inheritdoc/>
         public IOrdering All() => _search.All();
 
+        /// <inheritdoc/>
         public IBooleanOperation ManagedQuery(string query, string[] fields = null) 
             => _search.ManagedQueryInternal(query, fields, _occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true) where T : struct
             => _search.RangeQueryInternal(fields, min, max, minInclusive: minInclusive, maxInclusive: maxInclusive, _occurrence);
 
+        /// <summary>
+        /// The category of the query
+        /// </summary>
         public string Category => _search.Category;
 
+        /// <inheritdoc/>
         public IBooleanOperation NativeQuery(string query) => _search.NativeQuery(query);
 
         /// <inheritdoc />
@@ -72,38 +91,50 @@ namespace Examine.Lucene.Search
             return bo;
         }
 
+        /// <inheritdoc/>
         public IBooleanOperation Id(string id) => _search.IdInternal(id, _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.Field<T>(string fieldName, T fieldValue)
             => _search.RangeQueryInternal<T>(new[] { fieldName }, fieldValue, fieldValue, true, true, _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.Field(string fieldName, string fieldValue)
             => _search.FieldInternal(fieldName, new ExamineValue(Examineness.Explicit, fieldValue), _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.Field(string fieldName, IExamineValue fieldValue)
             => _search.FieldInternal(fieldName, fieldValue, _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.GroupedAnd(IEnumerable<string> fields, params string[] query)
             => _search.GroupedAndInternal(fields.ToArray(), query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray(), _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.GroupedAnd(IEnumerable<string> fields, params IExamineValue[] query)
             => _search.GroupedAndInternal(fields.ToArray(), query, _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.GroupedOr(IEnumerable<string> fields, params string[] query)
             => _search.GroupedOrInternal(fields.ToArray(), query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray(), _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.GroupedOr(IEnumerable<string> fields, params IExamineValue[] query)
             => _search.GroupedOrInternal(fields.ToArray(), query, _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.GroupedNot(IEnumerable<string> fields, params string[] query)
             => _search.GroupedNotInternal(fields.ToArray(), query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.GroupedNot(IEnumerable<string> fields, params IExamineValue[] query)
             => _search.GroupedNotInternal(fields.ToArray(), query);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.ManagedQuery(string query, string[] fields) 
             => _search.ManagedQueryInternal(query, fields, _occurrence);
 
+        /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive, bool maxInclusive)
             => _search.RangeQueryInternal(fields, min, max, minInclusive: minInclusive, maxInclusive: maxInclusive, _occurrence);
     }

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -52,6 +52,10 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <summary>
+        /// Executes a query
+        /// </summary>
+        /// <returns></returns>
         public ISearchResults Execute()
         {
             var extractTermsSupported = CheckQueryForExtractTerms(_luceneQuery);
@@ -197,7 +201,7 @@ namespace Examine.Lucene.Search
         }
 
         /// <summary>
-        /// Creates the search result from a <see cref="Lucene.Net.Documents.Document"/>
+        /// Creates the search result from a <see cref="Document"/>
         /// </summary>
         /// <param name="doc">The doc to convert.</param>
         /// <param name="score">The score.</param>

--- a/src/Examine.Lucene/Search/LuceneSearchOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchOptions.cs
@@ -10,71 +10,71 @@ namespace Examine.Lucene.Search
     /// </summary>
     public class LuceneSearchOptions
     {
-        //
-        // Summary:
-        //     Whether terms of multi-term queries (e.g., wildcard, prefix, fuzzy and range)
-        //     should be automatically lower-cased or not. Default is true.
+        /// <summary>
+        /// Whether terms of multi-term queries (e.g., wildcard, prefix, fuzzy and range)
+        /// should be automatically lower-cased or not. Default is true.
+        /// </summary>
         public bool? LowercaseExpandedTerms { get; set; }
 
-        //
-        // Summary:
-        //     Set to true to allow leading wildcard characters.
-        //     When set, * or ? are allowed as the first character of a Lucene.Net.Search.PrefixQuery
-        //     and Lucene.Net.Search.WildcardQuery. Note that this can produce very slow queries
-        //     on big indexes.
-        //     Default: false.
+        /// <summary>
+        /// Set to true to allow leading wildcard characters.
+        /// When set, * or ? are allowed as the first character of a Lucene.Net.Search.PrefixQuery
+        /// and Lucene.Net.Search.WildcardQuery. Note that this can produce very slow queries
+        /// on big indexes.
+        /// Default: false.
+        /// </summary>
         public bool? AllowLeadingWildcard { get; set; }
 
-        //
-        // Summary:
-        //     Set to true to enable position increments in result query.
-        //     When set, result phrase and multi-phrase queries will be aware of position increments.
-        //     Useful when e.g. a Lucene.Net.Analysis.Core.StopFilter increases the position
-        //     increment of the token that follows an omitted token.
-        //     Default: false.
+        /// <summary>
+        /// Set to true to enable position increments in result query.
+        /// When set, result phrase and multi-phrase queries will be aware of position increments.
+        /// Useful when e.g. a Lucene.Net.Analysis.Core.StopFilter increases the position
+        /// increment of the token that follows an omitted token.
+        /// Default: false.
+        /// </summary>
         public bool? EnablePositionIncrements { get; set; }
 
-        //
-        // Summary:
-        //     By default, it uses Lucene.Net.Search.MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT
-        //     when creating a prefix, wildcard and range queries. This implementation is generally
-        //     preferable because it a) Runs faster b) Does not have the scarcity of terms unduly
-        //     influence score c) avoids any exception due to too many listeners. However, if
-        //     your application really needs to use the old-fashioned boolean queries expansion
-        //     rewriting and the above points are not relevant then use this change the rewrite
-        //     method.
+        /// <summary>
+        /// By default, it uses Lucene.Net.Search.MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT
+        /// when creating a prefix, wildcard and range queries. This implementation is generally
+        /// preferable because it a) Runs faster b) Does not have the scarcity of terms unduly
+        /// influence score c) avoids any exception due to too many listeners. However, if
+        /// your application really needs to use the old-fashioned boolean queries expansion
+        /// rewriting and the above points are not relevant then use this change the rewrite
+        /// method.
+        /// </summary>
         public MultiTermQuery.RewriteMethod MultiTermRewriteMethod { get; set; }
 
-        //
-        // Summary:
-        //     Get or Set the prefix length for fuzzy queries. Default is 0.
+        /// <summary>
+        /// Get or Set the prefix length for fuzzy queries. Default is 0.
+        /// </summary>
         public int? FuzzyPrefixLength { get; set; }
 
-        //
-        // Summary:
-        //     Get or Set locale used by date range parsing.
+        /// <summary>
+        /// Get or Set locale used by date range parsing.
+        /// </summary>
         public CultureInfo Locale { get; set; }
 
-        //
-        // Summary:
-        //     Gets or Sets the time zone.
+        /// <summary>
+        /// Gets or Sets the time zone.
+        /// </summary>
         public TimeZoneInfo TimeZone { get; set; }
 
-        //
-        // Summary:
-        //     Gets or Sets the default slop for phrases. If zero, then exact phrase matches
-        //     are required. Default value is zero.
+        /// <summary>
+        /// Gets or Sets the default slop for phrases. If zero, then exact phrase matches
+        /// are required. Default value is zero.
+        /// </summary>
         public int? PhraseSlop { get; set; }
 
-        //
-        // Summary:
-        //     Get the minimal similarity for fuzzy queries.
+        /// <summary>
+        /// Get the minimal similarity for fuzzy queries.
+        /// </summary>
         public float? FuzzyMinSim { get; set; }
 
-        //
-        // Summary:
-        //     Sets the default Lucene.Net.Documents.DateTools.Resolution used for certain field
-        //     when no Lucene.Net.Documents.DateTools.Resolution is defined for this field.
+        /// <summary>
+        /// Sets the default Lucene.Net.Documents.DateTools.Resolution used for certain field
+        /// when no Lucene.Net.Documents.DateTools.Resolution is defined for this field.
+        /// </summary>
         public DateResolution? DateResolution { get; set; }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -21,6 +21,7 @@ namespace Examine.Lucene.Search
         private ISet<string> _fieldsToLoad = null;
         private readonly IList<IFacetField> _facetFields = new List<IFacetField>();
 
+        /// <inheritdoc/>
         public LuceneSearchQuery(
             ISearchContext searchContext,
             string category, Analyzer analyzer, LuceneSearchOptions searchOptions, BooleanOperation occurance, FacetsConfig facetsConfig)
@@ -81,25 +82,41 @@ namespace Examine.Lucene.Search
             return parser;
         }
 
+        /// <summary>
+        /// Sets the order by of the query
+        /// </summary>
+        /// <param name="fields"></param>
+        /// <returns></returns>
         public virtual IBooleanOperation OrderBy(params SortableField[] fields) => OrderByInternal(false, fields);
 
+        /// <summary>
+        /// Sets the order by of the query in a descending manner
+        /// </summary>
+        /// <param name="fields"></param>
+        /// <returns></returns>
         public virtual IBooleanOperation OrderByDescending(params SortableField[] fields) => OrderByInternal(true, fields);
 
+        /// <inheritdoc/>
         public override IBooleanOperation Field<T>(string fieldName, T fieldValue)
             => RangeQueryInternal<T>(new[] { fieldName }, fieldValue, fieldValue, true, true, Occurrence);
 
+        /// <inheritdoc/>
         public override IBooleanOperation ManagedQuery(string query, string[] fields = null)
             => ManagedQueryInternal(query, fields, Occurrence);
 
+        /// <inheritdoc/>
         public override IBooleanOperation RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true)
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
+        /// <inheritdoc/>
         protected override INestedBooleanOperation FieldNested<T>(string fieldName, T fieldValue)
             => RangeQueryInternal<T>(new[] { fieldName }, fieldValue, fieldValue, true, true, Occurrence);
 
+        /// <inheritdoc/>
         protected override INestedBooleanOperation ManagedQueryNested(string query, string[] fields = null)
             => ManagedQueryInternal(query, fields, Occurrence);
 
+        /// <inheritdoc/>
         protected override INestedBooleanOperation RangeQueryNested<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true)
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
@@ -305,12 +322,20 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
+        /// <summary>
+        /// Selects all fields
+        /// </summary>
+        /// <returns></returns>
         public IBooleanOperation SelectAllFieldsInternal()
         {
             _fieldsToLoad = null;
             return CreateOp();
         }
 
+        /// <summary>
+        /// Creates a new <see cref="LuceneBooleanOperation"/>
+        /// </summary>
+        /// <returns></returns>
         protected override LuceneBooleanOperationBase CreateOp() => new LuceneBooleanOperation(this);
 
         internal IFacetOperations FacetInternal(string field, Action<IFacetQueryField> facetConfiguration, params string[] values)

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -9,19 +9,37 @@ using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a base for <see cref="LuceneSearchQuery"/>
+    /// </summary>
     public abstract class LuceneSearchQueryBase : IQuery, INestedQuery
     {
         private readonly CustomMultiFieldQueryParser _queryParser;
+
+        /// <summary>
+        /// The query parser of the query
+        /// </summary>
         public QueryParser QueryParser => _queryParser;
 
         internal Stack<BooleanQuery> Queries { get; } = new Stack<BooleanQuery>();
+
+        /// <summary>
+        /// The <see cref="BooleanQuery"/>
+        /// </summary>
         public BooleanQuery Query => Queries.Peek();
 
+        /// <summary>
+        /// The sort fields of the query
+        /// </summary>
         public IList<SortField> SortFields { get; } = new List<SortField>();
 
+        /// <summary>
+        /// Specifies how clauses are to occur in matching documents
+        /// </summary>
         protected Occur Occurrence { get; set; }
         private BooleanOperation _boolOp;
 
+        /// <inheritdoc/>
         protected LuceneSearchQueryBase(CustomMultiFieldQueryParser queryParser,
             string category, LuceneSearchOptions searchOptions, BooleanOperation occurance)
         {
@@ -32,8 +50,15 @@ namespace Examine.Lucene.Search
             _queryParser = queryParser;
         }
 
+        /// <summary>
+        /// Creates a <see cref="LuceneBooleanOperationBase"/>
+        /// </summary>
+        /// <returns></returns>
         protected abstract LuceneBooleanOperationBase CreateOp();
 
+        /// <summary>
+        /// The type of boolean operation
+        /// </summary>
         public BooleanOperation BooleanOperation
         {
             get => _boolOp;
@@ -44,10 +69,19 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <summary>
+        /// The category of the query
+        /// </summary>
         public string Category { get; }
 
+        /// <summary>
+        /// All the searchable fields of the query
+        /// </summary>
         public string[] AllFields => _queryParser.SearchableFields;
 
+        /// <summary>
+        /// The query search options
+        /// </summary>
         public LuceneSearchOptions SearchOptions { get; }
 
         /// <inheritdoc />
@@ -58,6 +92,7 @@ namespace Examine.Lucene.Search
             return bo;
         }
 
+        /// <inheritdoc/>
         public IOrdering All()
         {
             Query.Add(new MatchAllDocsQuery(), BooleanOperation.ToLuceneOccurrence());
@@ -83,21 +118,31 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
+        /// <inheritdoc/>
         public IBooleanOperation Id(string id) => IdInternal(id, Occurrence);
 
+        /// <inheritdoc/>
         public abstract IBooleanOperation Field<T>(string fieldName, T fieldValue) where T : struct;
+
+        /// <inheritdoc/>
         public abstract IBooleanOperation ManagedQuery(string query, string[] fields = null);
+
+        /// <inheritdoc/>
         public abstract IBooleanOperation RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true) where T : struct;
 
+        /// <inheritdoc/>
         public IBooleanOperation Field(string fieldName, string fieldValue)
             => FieldInternal(fieldName, new ExamineValue(Examineness.Explicit, fieldValue), Occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation Field(string fieldName, IExamineValue fieldValue)
             => FieldInternal(fieldName, fieldValue, Occurrence);
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params string[] query)
             => GroupedAnd(fields, query?.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params IExamineValue[] fieldVals)
         {
             if (fields == null)
@@ -108,9 +153,11 @@ namespace Examine.Lucene.Search
             return GroupedAndInternal(fields.ToArray(), fieldVals, Occurrence);
         }
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedOr(IEnumerable<string> fields, params string[] query)
             => GroupedOr(fields, query?.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedOr(IEnumerable<string> fields, params IExamineValue[] query)
         {
             if (fields == null)
@@ -121,9 +168,11 @@ namespace Examine.Lucene.Search
             return GroupedOrInternal(fields.ToArray(), query, Occurrence);
         }
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedNot(IEnumerable<string> fields, params string[] query)
             => GroupedNot(fields, query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
+        /// <inheritdoc/>
         public IBooleanOperation GroupedNot(IEnumerable<string> fields, params IExamineValue[] query)
         {
             if (fields == null)
@@ -138,8 +187,34 @@ namespace Examine.Lucene.Search
 
         private static readonly string[] s_emptyStringArray = new string[0];
 
+        /// <summary>
+        /// Query on a specific field
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="fieldName"></param>
+        /// <param name="fieldValue"></param>
+        /// <returns></returns>
         protected abstract INestedBooleanOperation FieldNested<T>(string fieldName, T fieldValue) where T : struct;
+
+        /// <summary>
+        /// The index will determine the most appropiate way to query the fields specified
+        /// </summary>
+        /// <param name="query"></param>
+        /// <param name="fields"></param>
+        /// <returns></returns>
         protected abstract INestedBooleanOperation ManagedQueryNested(string query, string[] fields = null);
+
+        /// <summary>
+        /// Matches items as defined by the IIndexFieldValueType used for the fields specified. 
+        /// If a type is not defined for a field name, or the type does not implement IIndexRangeValueType for the types of min and max, nothing will be added
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="fields"></param>
+        /// <param name="min"></param>
+        /// <param name="max"></param>
+        /// <param name="minInclusive"></param>
+        /// <param name="maxInclusive"></param>
+        /// <returns></returns>
         protected abstract INestedBooleanOperation RangeQueryNested<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true) where T : struct;
 
         INestedBooleanOperation INestedQuery.Field(string fieldName, string fieldValue)
@@ -177,6 +252,7 @@ namespace Examine.Lucene.Search
 
         #region Internal
 
+        /// <inheritdoc/>
         protected internal LuceneBooleanOperationBase FieldInternal(string fieldName, IExamineValue fieldValue, Occur occurrence)
         {
             if (fieldName == null)
@@ -186,6 +262,7 @@ namespace Examine.Lucene.Search
             return FieldInternal(fieldName, fieldValue, occurrence, true);
         }
 
+        /// <inheritdoc/>
         private LuceneBooleanOperationBase FieldInternal(string fieldName, IExamineValue fieldValue, Occur occurrence, bool useQueryParser)
         {
             Query queryToAdd = GetFieldInternalQuery(fieldName, fieldValue, useQueryParser);
@@ -196,6 +273,7 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
+        /// <inheritdoc/>
         protected internal LuceneBooleanOperationBase GroupedAndInternal(string[] fields, IExamineValue[] fieldVals, Occur occurrence)
         {
             if (fields == null)
@@ -212,6 +290,7 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
+        /// <inheritdoc/>
         protected internal LuceneBooleanOperationBase GroupedNotInternal(string[] fields, IExamineValue[] fieldVals)
         {
             if (fields == null)
@@ -247,6 +326,7 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
+        /// <inheritdoc/>
         protected internal LuceneBooleanOperationBase GroupedOrInternal(string[] fields, IExamineValue[] fieldVals, Occur occurrence)
         {
             if (fields == null)
@@ -263,6 +343,7 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
+        /// <inheritdoc/>
         protected internal LuceneBooleanOperationBase IdInternal(string id, Occur occurrence)
         {
             if (id == null)

--- a/src/Examine.Lucene/Search/LuceneSearchResults.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchResults.cs
@@ -5,12 +5,19 @@ using Examine.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents the search results of a query
+    /// </summary>
     public class LuceneSearchResults : ISearchResults, IFacetResults
     {
+        /// <summary>
+        /// Gets an empty search result
+        /// </summary>
         public static LuceneSearchResults Empty { get; } = new LuceneSearchResults(Array.Empty<ISearchResult>(), 0, new Dictionary<string, IFacetResult>());
 
         private readonly IReadOnlyCollection<ISearchResult> _results;
 
+        /// <inheritdoc/>
         public LuceneSearchResults(IReadOnlyCollection<ISearchResult> results, int totalItemCount, IReadOnlyDictionary<string, IFacetResult> facets)
         {
             _results = results;
@@ -18,11 +25,16 @@ namespace Examine.Lucene.Search
             Facets = facets;
         }
 
+        /// <inheritdoc/>
         public long TotalItemCount { get; }
 
+        /// <inheritdoc/>
         public IReadOnlyDictionary<string, IFacetResult> Facets { get; }
 
+        /// <inheritdoc/>
         public IEnumerator<ISearchResult> GetEnumerator() => _results.GetEnumerator();
+
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Examine.Lucene/Search/MultiSearchContext.cs
+++ b/src/Examine.Lucene/Search/MultiSearchContext.cs
@@ -4,20 +4,26 @@ using Examine.Lucene.Indexing;
 
 namespace Examine.Lucene.Search
 {
-
+    /// <summary>
+    /// Represents a multi search context
+    /// </summary>
     public class MultiSearchContext : ISearchContext
     {
         private readonly ISearchContext[] _inner;
         
         private string[] _fields;
-        
+
+        /// <inheritdoc/>
         public MultiSearchContext(ISearchContext[] inner) => _inner = inner;
 
+        /// <inheritdoc/>
         public ISearcherReference GetSearcher()
             => new MultiSearchSearcherReference(_inner.Select(x => x.GetSearcher()).ToArray());
 
+        /// <inheritdoc/>
         public string[] SearchableFields => _fields ?? (_fields = _inner.SelectMany(x => x.SearchableFields).Distinct().ToArray());
 
+        /// <inheritdoc/>
         public IIndexFieldValueType GetFieldValueType(string fieldName)
             => _inner.Select(cc => cc.GetFieldValueType(fieldName)).FirstOrDefault(type => type != null);
 

--- a/src/Examine.Lucene/Search/MultiSearchSearcherReference.cs
+++ b/src/Examine.Lucene/Search/MultiSearchSearcherReference.cs
@@ -1,16 +1,21 @@
-﻿using Lucene.Net.Index;
+using Lucene.Net.Index;
 using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Represents a multi search searcher reference
+    /// </summary>
     public class MultiSearchSearcherReference : ISearcherReference
     {
+        /// <inheritdoc/>
         public MultiSearchSearcherReference(ISearcherReference[] inner) => _inner = inner;
 
         private bool _disposedValue;
         private IndexSearcher _searcher;
         private readonly ISearcherReference[] _inner;
 
+        /// <inheritdoc/>
         public IndexSearcher IndexSearcher
         {
             get
@@ -29,6 +34,7 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -45,6 +51,7 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/src/Examine.Lucene/Search/SearchContext.cs
+++ b/src/Examine.Lucene/Search/SearchContext.cs
@@ -8,20 +8,24 @@ using Lucene.Net.Search;
 namespace Examine.Lucene.Search
 {
 
+    /// <inheritdoc/>
     public class SearchContext : ISearchContext
     {
         private readonly SearcherManager _searcherManager;
         private readonly FieldValueTypeCollection _fieldValueTypeCollection;
         private string[] _searchableFields;
 
+        /// <inheritdoc/>
         public SearchContext(SearcherManager searcherManager, FieldValueTypeCollection fieldValueTypeCollection)
         {
             _searcherManager = searcherManager;            
             _fieldValueTypeCollection = fieldValueTypeCollection ?? throw new ArgumentNullException(nameof(fieldValueTypeCollection));
         }
 
+        /// <inheritdoc/>
         public ISearcherReference GetSearcher() => new SearcherReference(_searcherManager);
 
+        /// <inheritdoc/>
         public string[] SearchableFields
         {
             get
@@ -53,6 +57,7 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <inheritdoc/>
         public IIndexFieldValueType GetFieldValueType(string fieldName)
         {
             //Get the value type for the field, or use the default if not defined

--- a/src/Examine.Lucene/Search/SearcherReference.cs
+++ b/src/Examine.Lucene/Search/SearcherReference.cs
@@ -3,17 +3,20 @@ using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
 {
+    /// <inheritdoc/>
     public class SearcherReference : ISearcherReference
     {
         private bool _disposedValue;
         private readonly SearcherManager _searcherManager;
         private IndexSearcher _searcher;
 
+        /// <inheritdoc/>
         public SearcherReference(SearcherManager searcherManager)
         {
             _searcherManager = searcherManager;
         }
 
+        /// <inheritdoc/>
         public IndexSearcher IndexSearcher
         {
             get
@@ -26,6 +29,7 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -42,6 +46,7 @@ namespace Examine.Lucene.Search
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/src/Examine.Lucene/ValueTypeFactoryCollection.cs
+++ b/src/Examine.Lucene/ValueTypeFactoryCollection.cs
@@ -27,6 +27,12 @@ namespace Examine.Lucene
                 valueTypeFactories,
                 StringComparer.InvariantCultureIgnoreCase);
 
+        /// <summary>
+        /// Try get for the factory
+        /// </summary>
+        /// <param name="valueTypeName"></param>
+        /// <param name="fieldValueTypeFactory"></param>
+        /// <returns></returns>
         public bool TryGetFactory(string valueTypeName, out IFieldValueTypeFactory fieldValueTypeFactory)
             => _valueTypeFactories.TryGetValue(valueTypeName, out fieldValueTypeFactory);
 
@@ -43,6 +49,9 @@ namespace Examine.Lucene
             return fieldValueTypeFactory;
         }
 
+        /// <summary>
+        /// The ammount of key/value pairs in the collection
+        /// </summary>
         public int Count => _valueTypeFactories.Count;
 
         /// <summary>
@@ -87,9 +96,11 @@ namespace Examine.Lucene
             };
 
 
+        /// <inheritdoc/>
         public IEnumerator<KeyValuePair<string, IFieldValueTypeFactory>> GetEnumerator()
             => _valueTypeFactories.GetEnumerator();
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
     }


### PR DESCRIPTION
This adds XML documentation to the facets feature as well as other places in the project. This means that this PR is a super set of #311 and should be merged after the facets feature.

To see the changes in this PR before merging #311 see [this commit](https://github.com/Shazwazza/Examine/commit/5ab8b4dff0a3449e5358afaf36cd890f5d063d64#diff-15152175bf24ccd6097049544e6719125d556beeeb9c42c61ac2b363498b7173)

## What changed

- Added `<GenerateDocumentationFile>True</GenerateDocumentationFile>` to project files
- Fixed XML warnings
- Added XML to new facets feature.

## Approach

- The XML information has been added with the information that could be interpreted by looking in the source code and documentation.
- Added `<inheritdoc />` to constructors without XML information. Constructor XML information is rarely needed so adding `<inheritdoc />` removes the XML warning.

## Remaining XML warnings

Some classes have not had XML added due to not knowing what the class / method is used to do.

 - `GenericDirectoryFactory`
 - `FileSystemDirectoryFactory`
 - `IApplicationIdentifier`
 - `IApplicationIdentifier.GetApplicationUniqueIdentifier()`
 - `IApplicationRoot`
 - `IApplicationRoot.ApplicationRoot`