### PR TITLE
Facets nullable (#311 & #307)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,5 +24,9 @@
   <PropertyGroup Condition="'$(MSBuildProjectName)' != 'Examine.Web.Demo' AND '$(MSBuildProjectName)' != 'Examine.Test'">
     <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-
+  
+  <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NoWarn>$(NoWarn);nullable</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/src/Examine.Core/BaseIndexProvider.cs
+++ b/src/Examine.Core/BaseIndexProvider.cs
@@ -43,7 +43,7 @@ namespace Examine
         /// <summary>
         /// A validator to validate a value set before it's indexed
         /// </summary>
-        public IValueSetValidator ValueSetValidator => _indexOptions.Validator;
+        public IValueSetValidator? ValueSetValidator => _indexOptions.Validator;
 
         /// <summary>
         /// Ensures that the node being indexed is of a correct type
@@ -110,13 +110,13 @@ namespace Examine
         #region Events
 
         /// <inheritdoc />
-        public event EventHandler<IndexOperationEventArgs> IndexOperationComplete;
+        public event EventHandler<IndexOperationEventArgs>? IndexOperationComplete;
 
         /// <inheritdoc />
-        public event EventHandler<IndexingErrorEventArgs> IndexingError;
+        public event EventHandler<IndexingErrorEventArgs>? IndexingError;
 
         /// <inheritdoc />
-        public event EventHandler<IndexingItemEventArgs> TransformingIndexValues;
+        public event EventHandler<IndexingItemEventArgs>? TransformingIndexValues;
 
         #endregion
 

--- a/src/Examine.Core/BaseSearchProvider.cs
+++ b/src/Examine.Core/BaseSearchProvider.cs
@@ -19,10 +19,10 @@ namespace Examine
         public string Name { get; }
 
         /// <inheritdoc/>
-        public abstract ISearchResults Search(string searchText, QueryOptions options = null);
+        public abstract ISearchResults Search(string searchText, QueryOptions? options = null);
 
         /// <inheritdoc />
-		public abstract IQuery CreateQuery(string category = null, BooleanOperation defaultOperation = BooleanOperation.And);
+		public abstract IQuery CreateQuery(string? category = null, BooleanOperation defaultOperation = BooleanOperation.And);
         
     }
 }

--- a/src/Examine.Core/Examine.Core.csproj
+++ b/src/Examine.Core/Examine.Core.csproj
@@ -6,6 +6,8 @@
     <Description>Examine is an abstraction for indexing and search operations with implementations such as Lucene.Net</Description>
     <PackageTags>examine search index</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examine.Core/ExamineExtensions.cs
+++ b/src/Examine.Core/ExamineExtensions.cs
@@ -37,7 +37,7 @@ namespace Examine
         /// <returns></returns>
         public static IIndex GetIndex(this IExamineManager examineManager, string indexName)
         {
-            if (examineManager.TryGetIndex(indexName, out IIndex index))
+            if (examineManager.TryGetIndex(indexName, out IIndex? index))
             {
                 return index;
             }

--- a/src/Examine.Core/ExamineManager.cs
+++ b/src/Examine.Core/ExamineManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Examine
@@ -28,11 +29,19 @@ namespace Examine
         private readonly ConcurrentDictionary<string, ISearcher> _searchers = new ConcurrentDictionary<string, ISearcher>(StringComparer.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
-        public bool TryGetSearcher(string searcherName, out ISearcher searcher) => 
+        public bool TryGetSearcher(string searcherName,
+#if !NETSTANDARD2_0
+            [MaybeNullWhen(false)]
+#endif
+            out ISearcher searcher) => 
             (searcher = _searchers.TryGetValue(searcherName, out var s) ? s : null) != null;
 
         /// <inheritdoc />
-        public bool TryGetIndex(string indexName, out IIndex index) => 
+        public bool TryGetIndex(string indexName,
+#if !NETSTANDARD2_0
+            [MaybeNullWhen(false)]
+#endif
+            out IIndex index) => 
             (index = _indexers.TryGetValue(indexName, out var i) ? i : null) != null;
 
         /// <inheritdoc />

--- a/src/Examine.Core/FieldDefinition.cs
+++ b/src/Examine.Core/FieldDefinition.cs
@@ -34,7 +34,7 @@ namespace Examine
         public bool Equals(FieldDefinition other) => string.Equals(Name, other.Name) && string.Equals(Type, other.Type);
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             return obj is FieldDefinition definition && Equals(definition);

--- a/src/Examine.Core/IExamineManager.cs
+++ b/src/Examine.Core/IExamineManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Examine
@@ -35,7 +36,11 @@ namespace Examine
         /// <param name="indexName"></param>
         /// <param name="index"></param>
         /// <returns>true if the index was found by name</returns>
-        bool TryGetIndex(string indexName, out IIndex index);
+        bool TryGetIndex(string indexName,
+#if !NETSTANDARD2_0
+            [MaybeNullWhen(false)]
+#endif
+            out IIndex index);
 
         /// <summary>
         /// Returns a searcher that was registered with AddExamineSearcher or via config
@@ -45,7 +50,11 @@ namespace Examine
         /// <returns>
         /// true if the searcher was found by name
         /// </returns>
-        bool TryGetSearcher(string searcherName, out ISearcher searcher);
+        bool TryGetSearcher(string searcherName,
+#if !NETSTANDARD2_0
+            [MaybeNullWhen(false)]
+#endif
+        out ISearcher searcher);
 
     }
 }

--- a/src/Examine.Core/ISearchResult.cs
+++ b/src/Examine.Core/ISearchResult.cs
@@ -50,6 +50,6 @@ namespace Examine
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        string this[string key] { get; }
+        string? this[string key] { get; }
     }
 }

--- a/src/Examine.Core/ISearcher.cs
+++ b/src/Examine.Core/ISearcher.cs
@@ -18,7 +18,7 @@ namespace Examine
         /// <param name="searchText">The search text or a native query</param>
         /// <param name="options"></param>
         /// <returns>Search Results</returns>
-        ISearchResults Search(string searchText, QueryOptions options = null);
+        ISearchResults Search(string searchText, QueryOptions? options = null);
 
         /// <summary>
         /// Creates a search criteria instance as required by the implementation
@@ -28,6 +28,6 @@ namespace Examine
         /// <returns>
         /// An instance of <see cref="IQueryExecutor"/>
         /// </returns>
-        IQuery CreateQuery(string category = null, BooleanOperation defaultOperation = BooleanOperation.And);
+        IQuery CreateQuery(string? category = null, BooleanOperation defaultOperation = BooleanOperation.And);
     }
 }

--- a/src/Examine.Core/IndexOptions.cs
+++ b/src/Examine.Core/IndexOptions.cs
@@ -16,6 +16,6 @@ namespace Examine
         /// <summary>
         /// The validator for the <see cref="IIndex"/>
         /// </summary>
-        public IValueSetValidator Validator { get; set; }
+        public IValueSetValidator? Validator { get; set; }
     }
 }

--- a/src/Examine.Core/IndexingErrorEventArgs.cs
+++ b/src/Examine.Core/IndexingErrorEventArgs.cs
@@ -11,7 +11,7 @@ namespace Examine
     public class IndexingErrorEventArgs : EventArgs
     {
         /// <inheritdoc/>
-        public IndexingErrorEventArgs(IIndex index, string message, string itemId, Exception exception)
+        public IndexingErrorEventArgs(IIndex index, string message, string? itemId, Exception? exception)
         {
             Index = index;
             ItemId = itemId;
@@ -22,7 +22,7 @@ namespace Examine
         /// <summary>
         /// The exception of the error
         /// </summary>
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
 
         /// <summary>
         /// The message of the error
@@ -37,6 +37,6 @@ namespace Examine
         /// <summary>
         /// The item id
         /// </summary>
-        public string ItemId { get; }
+        public string? ItemId { get; }
     }
 }

--- a/src/Examine.Core/OrderedDictionary.cs
+++ b/src/Examine.Core/OrderedDictionary.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Examine
@@ -10,7 +11,7 @@ namespace Examine
     /// </summary>
     /// <typeparam name="TKey"></typeparam>
     /// <typeparam name="TVal"></typeparam>
-    public class OrderedDictionary<TKey, TVal> : KeyedCollection<TKey, KeyValuePair<TKey, TVal>>, IDictionary<TKey, TVal>, IReadOnlyDictionary<TKey, TVal>
+    public class OrderedDictionary<TKey, TVal> : KeyedCollection<TKey, KeyValuePair<TKey, TVal>>, IDictionary<TKey, TVal>, IReadOnlyDictionary<TKey, TVal> where TKey : notnull
     {
         /// <inheritdoc/>
         public OrderedDictionary()
@@ -64,7 +65,14 @@ namespace Examine
         }
 
         /// <inheritdoc/>
-        public bool TryGetValue(TKey key, out TVal value)
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        // Justification for warning disabled: IDictionary is missing [MaybeNullWhen(false)] in Netstandard 2.1
+        public bool TryGetValue(TKey key,
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+#if !NETSTANDARD2_0
+            [MaybeNullWhen(false)]
+#endif
+            out TVal value)
         {
             if (base.Dictionary == null)
             {
@@ -97,7 +105,7 @@ namespace Examine
                 {
                     return found.Value;
                 }
-                return default(TVal);
+                return default(TVal); // TODO: should this throw instead
             }
             set
             {

--- a/src/Examine.Core/OrderedDictionary.cs
+++ b/src/Examine.Core/OrderedDictionary.cs
@@ -105,7 +105,7 @@ namespace Examine
                 {
                     return found.Value;
                 }
-                return default(TVal); // TODO: should this throw instead
+                throw new KeyNotFoundException();
             }
             set
             {

--- a/src/Examine.Core/Search/FacetResult.cs
+++ b/src/Examine.Core/Search/FacetResult.cs
@@ -31,7 +31,7 @@ namespace Examine.Search
         }
 
         /// <inheritdoc/>
-        public IFacetValue Facet(string label)
+        public IFacetValue? Facet(string label)
         {
             SetValuesDictionary();
             return _dictValues[label];

--- a/src/Examine.Core/Search/FacetResult.cs
+++ b/src/Examine.Core/Search/FacetResult.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Examine.Search
@@ -8,7 +9,12 @@ namespace Examine.Search
     public class FacetResult : IFacetResult
     {
         private readonly IEnumerable<IFacetValue> _values;
+#if NETSTANDARD2_1
+        [AllowNull]
         private IDictionary<string, IFacetValue> _dictValues;
+#else
+        private IDictionary<string, IFacetValue>? _dictValues;
+#endif
 
         /// <inheritdoc/>
         public FacetResult(IEnumerable<IFacetValue> values)
@@ -22,6 +28,9 @@ namespace Examine.Search
             return _values.GetEnumerator();
         }
 
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+        [MemberNotNull(nameof(_dictValues))]
+#endif
         private void SetValuesDictionary()
         {
             if(_dictValues == null)
@@ -38,7 +47,7 @@ namespace Examine.Search
         }
 
         /// <inheritdoc/>
-        public bool TryGetFacet(string label, out IFacetValue facetValue)
+        public bool TryGetFacet(string label, out IFacetValue? facetValue)
         {
             SetValuesDictionary();
             return _dictValues.TryGetValue(label, out facetValue);

--- a/src/Examine.Core/Search/IFacetOperations.cs
+++ b/src/Examine.Core/Search/IFacetOperations.cs
@@ -14,7 +14,7 @@ namespace Examine.Search
         /// <param name="field"></param>
         /// <param name="facetConfiguration"></param>
         /// <returns></returns>
-        IFacetOperations Facet(string field, Action<IFacetQueryField> facetConfiguration = null);
+        IFacetOperations Facet(string field, Action<IFacetQueryField>? facetConfiguration = null);
 
         /// <summary>
         /// Add a facet string to the current query, filtered by a single value or multiple values
@@ -23,7 +23,7 @@ namespace Examine.Search
         /// <param name="facetConfiguration"></param>
         /// <param name="values"></param>
         /// <returns></returns>
-        IFacetOperations Facet(string field, Action<IFacetQueryField> facetConfiguration = null, params string[] values);
+        IFacetOperations Facet(string field, Action<IFacetQueryField>? facetConfiguration = null, params string[] values);
 
         /// <summary>
         /// Add a range facet to the current query

--- a/src/Examine.Core/Search/IFacetResult.cs
+++ b/src/Examine.Core/Search/IFacetResult.cs
@@ -12,7 +12,7 @@ namespace Examine.Search
         /// </summary>
         /// <param name="label"></param>
         /// <returns></returns>
-        IFacetValue Facet(string label);
+        IFacetValue? Facet(string label);
 
         /// <summary>
         /// Trys to get a facet value for a label
@@ -20,6 +20,6 @@ namespace Examine.Search
         /// <param name="label"></param>
         /// <param name="facetValue"></param>
         /// <returns></returns>
-        bool TryGetFacet(string label, out IFacetValue facetValue);
+        bool TryGetFacet(string label, out IFacetValue? facetValue);
     }
 }

--- a/src/Examine.Core/Search/INestedQuery.cs
+++ b/src/Examine.Core/Search/INestedQuery.cs
@@ -86,7 +86,7 @@ namespace Examine.Search
         /// <param name="query"></param>
         /// <param name="fields"></param>
         /// <returns></returns>
-        INestedBooleanOperation ManagedQuery(string query, string[] fields = null);
+        INestedBooleanOperation ManagedQuery(string query, string[]? fields = null);
 
         /// <summary>
         /// Matches items as defined by the IIndexFieldValueType used for the fields specified. 

--- a/src/Examine.Core/Search/IQuery.cs
+++ b/src/Examine.Core/Search/IQuery.cs
@@ -120,7 +120,7 @@ namespace Examine.Search
         /// <param name="query"></param>
         /// <param name="fields"></param>
         /// <returns></returns>
-        IBooleanOperation ManagedQuery(string query, string[] fields = null);
+        IBooleanOperation ManagedQuery(string query, string[]? fields = null);
 
         /// <summary>
         /// Matches items as defined by the IIndexFieldValueType used for the fields specified. 

--- a/src/Examine.Core/Search/IQueryExecutor.cs
+++ b/src/Examine.Core/Search/IQueryExecutor.cs
@@ -9,6 +9,6 @@ namespace Examine.Search
         /// <summary>
         /// Executes the query
         /// </summary>
-        ISearchResults Execute(QueryOptions options = null);
+        ISearchResults Execute(QueryOptions? options = null);
     }
 }

--- a/src/Examine.Core/SearchResult.cs
+++ b/src/Examine.Core/SearchResult.cs
@@ -8,7 +8,7 @@ namespace Examine
     /// <inheritdoc/>
     public class SearchResult : ISearchResult
     {
-        private OrderedDictionary<string, string> _fields;
+        private OrderedDictionary<string, string>? _fields;
         private readonly Lazy<OrderedDictionary<string, IReadOnlyList<string>>> _fieldValues;
 
         /// <summary>
@@ -98,14 +98,14 @@ namespace Examine
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        public string this[string key] => Values.TryGetValue(key, out var single) ? single : null;
+        public string? this[string key] => Values.TryGetValue(key, out var single) ? single : null;
 
         /// <summary>
         /// Override this method so that the Distinct() operator works
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj == null || GetType() != obj.GetType())
                 return false;

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,17 +20,17 @@ namespace Examine
         /// <remarks>
         /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
         /// </remarks>
-        public string Category { get; }
+        public string? Category { get; }
 
         /// <summary>
         /// The item's node type (in umbraco terms this would be the doc type alias)
         /// </summary>
-        public string ItemType { get; }
+        public string? ItemType { get; }
 
         /// <summary>
         /// The values to be indexed
         /// </summary>
-        public IReadOnlyDictionary<string, IReadOnlyList<object>> Values { get; }
+        public IReadOnlyDictionary<string, IReadOnlyList<object>>? Values { get; }
 
         /// <summary>
         /// Constructor that only specifies an ID
@@ -109,17 +110,17 @@ namespace Examine
         /// Used to categorize the item in the index (in umbraco terms this would be content vs media)
         /// </param>
         /// <param name="values"></param>
-        public ValueSet(string id, string category, string itemType, IDictionary<string, IEnumerable<object>> values)
+        public ValueSet(string id, string? category, string? itemType, IDictionary<string, IEnumerable<object>> values)
             : this(id, category, itemType, values.ToDictionary(x => x.Key, x => (IReadOnlyList<object>)x.Value.ToList()))
         {
         }
 
-        private ValueSet(string id, string category, string itemType, IReadOnlyDictionary<string, IReadOnlyList<object>> values)
+        private ValueSet(string id, string? category, string? itemType, IReadOnlyDictionary<string, IReadOnlyList<object>>? values)
         {
             Id = id;
             Category = category;
             ItemType = itemType;
-            Values = values.ToDictionary(x => x.Key, x => (IReadOnlyList<object>)x.Value.ToList());
+            Values = values?.ToDictionary(x => x.Key, x => (IReadOnlyList<object>)x.Value.ToList()) ?? default;
         }
 
         /// <summary>
@@ -129,7 +130,7 @@ namespace Examine
         /// <returns></returns>
         public IEnumerable<object> GetValues(string key)
         {
-            return !Values.TryGetValue(key, out var values) ? Enumerable.Empty<object>() : values;
+            return Values != null && Values.TryGetValue(key, out var values) ? values : Enumerable.Empty<object>();
         }
 
         /// <summary>
@@ -139,9 +140,9 @@ namespace Examine
         /// <returns>
         /// If there are multiple values, this will return the first
         /// </returns>
-        public object GetValue(string key)
+        public object? GetValue(string key)
         {
-            return !Values.TryGetValue(key, out var values) ? null : values.Count > 0 ? values[0] : null;
+            return Values != null && Values.TryGetValue(key, out var values) ? values.Count > 0 ? values[0] : null : null;
         }
 
         /// <summary>

--- a/src/Examine.Host/Examine.csproj
+++ b/src/Examine.Host/Examine.csproj
@@ -4,6 +4,8 @@
     <Description>A Lucene.Net search and indexing implementation for Examine</Description>
     <PackageTags>examine lucene lucene.net lucenenet search index</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examine.Host/ServicesCollectionExtensions.cs
+++ b/src/Examine.Host/ServicesCollectionExtensions.cs
@@ -25,11 +25,11 @@ namespace Examine
         public static IServiceCollection AddExamineLuceneIndex(
             this IServiceCollection serviceCollection,
             string name,
-            FieldDefinitionCollection fieldDefinitions = null,
-            Analyzer analyzer = null,
-            IValueSetValidator validator = null,
-            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null,
-            FacetsConfig facetsConfig = null)
+            FieldDefinitionCollection? fieldDefinitions = null,
+            Analyzer? analyzer = null,
+            IValueSetValidator? validator = null,
+            IReadOnlyDictionary<string, IFieldValueTypeFactory>? indexValueTypesFactory = null,
+            FacetsConfig? facetsConfig = null)
             => serviceCollection.AddExamineLuceneIndex<LuceneIndex>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig);
 
         /// <summary>
@@ -38,11 +38,11 @@ namespace Examine
         public static IServiceCollection AddExamineLuceneIndex<TIndex>(
             this IServiceCollection serviceCollection,
             string name,
-            FieldDefinitionCollection fieldDefinitions = null,
-            Analyzer analyzer = null,
-            IValueSetValidator validator = null,
-            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null,
-            FacetsConfig facetsConfig = null)
+            FieldDefinitionCollection? fieldDefinitions = null,
+            Analyzer? analyzer = null,
+            IValueSetValidator? validator = null,
+            IReadOnlyDictionary<string, IFieldValueTypeFactory>? indexValueTypesFactory = null,
+            FacetsConfig? facetsConfig = null)
             where TIndex : LuceneIndex
             => serviceCollection.AddExamineLuceneIndex<TIndex, FileSystemDirectoryFactory>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig);
 
@@ -52,11 +52,11 @@ namespace Examine
         public static IServiceCollection AddExamineLuceneIndex<TIndex, TDirectoryFactory>(
             this IServiceCollection serviceCollection,
             string name,
-            FieldDefinitionCollection fieldDefinitions = null,
-            Analyzer analyzer = null,
-            IValueSetValidator validator = null,
-            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null,
-            FacetsConfig facetsConfig = null)
+            FieldDefinitionCollection? fieldDefinitions = null,
+            Analyzer? analyzer = null,
+            IValueSetValidator? validator = null,
+            IReadOnlyDictionary<string, IFieldValueTypeFactory>? indexValueTypesFactory = null,
+            FacetsConfig? facetsConfig = null)
             where TIndex : LuceneIndex
             where TDirectoryFactory : class, IDirectoryFactory
         {
@@ -122,7 +122,7 @@ namespace Examine
             this IServiceCollection serviceCollection,
             string name,
             string[] indexNames,
-            Analyzer analyzer = null)
+            Analyzer? analyzer = null)
             => serviceCollection.AddExamineSearcher<MultiIndexSearcher>(name, s =>
             {
                 IEnumerable<IIndex> matchedIndexes = s.GetServices<IIndex>()
@@ -147,7 +147,7 @@ namespace Examine
         /// <param name="services"></param>
         /// <param name="appRootDirectory"></param>
         /// <returns></returns>
-        public static IServiceCollection AddExamine(this IServiceCollection services, DirectoryInfo appRootDirectory = null)
+        public static IServiceCollection AddExamine(this IServiceCollection services, DirectoryInfo? appRootDirectory = null)
         {
             services.TryAddSingleton<IApplicationRoot, CurrentEnvironmentApplicationRoot>();
             services.TryAddSingleton<IExamineManager, ExamineManager>();

--- a/src/Examine.Lucene/Analyzers/CultureInvariantWhitespaceAnalyzer.cs
+++ b/src/Examine.Lucene/Analyzers/CultureInvariantWhitespaceAnalyzer.cs
@@ -36,7 +36,7 @@ namespace Examine.Lucene.Analyzers
         {
             Tokenizer tokenizer = new LetterOrDigitTokenizer(reader);
 
-            TokenStream result = null;
+            TokenStream? result = null;
 
             if (_caseInsensitive)
             {

--- a/src/Examine.Lucene/Analyzers/PatternAnalyzer.cs
+++ b/src/Examine.Lucene/Analyzers/PatternAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Examine.Lucene.Analyzers
     {
         private readonly int _regexGroup;
         private readonly bool _lowercase;
-        private readonly CharArraySet _stopWords;
+        private readonly CharArraySet? _stopWords;
         private readonly Regex _pattern;
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace Examine.Lucene.Analyzers
         /// <param name="regexGroup">The regex group number to match. -1 to use as a split.</param>
         /// <param name="lowercase">Whether to lower case the tokens</param>
         /// <param name="stopWords">Any stop words that should be included</param>
-        public PatternAnalyzer(string format, int regexGroup, bool lowercase = false, CharArraySet stopWords = null)
+        public PatternAnalyzer(string format, int regexGroup, bool lowercase = false, CharArraySet? stopWords = null)
         {
             _regexGroup = regexGroup;
             _lowercase = lowercase;

--- a/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs
@@ -24,7 +24,7 @@ namespace Examine.Lucene.Directories
     {
         private readonly DirectoryInfo _localDir;
         private readonly ILoggerFactory _loggerFactory;
-        private ExamineReplicator _replicator;
+        private ExamineReplicator? _replicator;
 
         /// <inheritdoc/>
         public SyncedFileSystemDirectoryFactory(

--- a/src/Examine.Lucene/Examine.Lucene.csproj
+++ b/src/Examine.Lucene/Examine.Lucene.csproj
@@ -5,6 +5,8 @@
     <Description>A Lucene.Net search and indexing implementation for Examine</Description>
     <PackageTags>examine lucene lucene.net lucenenet search index</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="AspExamineManager.cs.bak" />

--- a/src/Examine.Lucene/ExamineReplicator.cs
+++ b/src/Examine.Lucene/ExamineReplicator.cs
@@ -125,12 +125,16 @@ namespace Examine.Lucene
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void SourceIndex_IndexCommitted(object sender, EventArgs e)
+        private void SourceIndex_IndexCommitted(object? sender, EventArgs e)
         {
-            var index = (LuceneIndex)sender;
+            var index = (LuceneIndex?)sender;
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("{IndexName} committed", index.Name);
+                if(index == null)
+                {
+                    _logger.LogWarning("Index is null in {method}", nameof(ExamineReplicator.SourceIndex_IndexCommitted));
+                }
+                _logger.LogDebug("{IndexName} committed", index?.Name ?? $"({nameof(index)} is null)");
             }
             var rev = new IndexRevision(_sourceIndex.IndexWriter.IndexWriter);
             _replicator.Publish(rev);

--- a/src/Examine.Lucene/FacetExtensions.cs
+++ b/src/Examine.Lucene/FacetExtensions.cs
@@ -13,14 +13,14 @@ namespace Examine.Lucene
         /// <summary>
         /// Get the values for a particular facet in the results
         /// </summary>
-        public static Examine.Search.IFacetResult GetFacet(this ISearchResults searchResults, string field)
+        public static Examine.Search.IFacetResult? GetFacet(this ISearchResults searchResults, string field)
         {
             if (!(searchResults is Examine.Search.IFacetResults facetResults))
             {
                 throw new NotSupportedException("Result does not support facets");
             }
 
-            facetResults.Facets.TryGetValue(field, out Examine.Search.IFacetResult facet);
+            facetResults.Facets.TryGetValue(field, out Examine.Search.IFacetResult? facet);
 
             return facet;
         }

--- a/src/Examine.Lucene/FieldValueTypeCollection.cs
+++ b/src/Examine.Lucene/FieldValueTypeCollection.cs
@@ -27,7 +27,7 @@ namespace Examine.Lucene
         {
             ValueTypeFactories = new ValueTypeFactoryCollection(valueTypeFactories);
 
-            var fieldAnalyzers = new Dictionary<string, Analyzer>();
+            var fieldAnalyzers = new Dictionary<string, Analyzer?>();
 
             //initializes the collection of field aliases to it's correct IIndexFieldValueType
             _resolvedValueTypes = new Lazy<ConcurrentDictionary<string, IIndexFieldValueType>>(() =>
@@ -97,7 +97,7 @@ namespace Examine.Lucene
         /// </exception>
         public IIndexFieldValueType GetValueType(string fieldName)
         {
-            if (!_resolvedValueTypes.Value.TryGetValue(fieldName, out IIndexFieldValueType valueType))
+            if (!_resolvedValueTypes.Value.TryGetValue(fieldName, out IIndexFieldValueType? valueType))
             {
                 throw new InvalidOperationException($"No {nameof(IIndexFieldValueType)} was found for field name {fieldName}");
             }

--- a/src/Examine.Lucene/Indexing/DateTimeType.cs
+++ b/src/Examine.Lucene/Indexing/DateTimeType.cs
@@ -72,7 +72,7 @@ namespace Examine.Lucene.Indexing
         }
 
         /// <inheritdoc/>
-        public override Query GetQuery(string query)
+        public override Query? GetQuery(string query)
         {
             if (!TryConvert(query, out DateTime parsedVal))
                 return null;

--- a/src/Examine.Lucene/Indexing/DoubleType.cs
+++ b/src/Examine.Lucene/Indexing/DoubleType.cs
@@ -52,7 +52,7 @@ namespace Examine.Lucene.Indexing
         }
 
         /// <inheritdoc/>
-        public override Query GetQuery(string query)
+        public override Query? GetQuery(string query)
         {
             return !TryConvert(query, out double parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }

--- a/src/Examine.Lucene/Indexing/FullTextType.cs
+++ b/src/Examine.Lucene/Indexing/FullTextType.cs
@@ -57,7 +57,7 @@ namespace Examine.Lucene.Indexing
         /// Defaults to <see cref="CultureInvariantStandardAnalyzer"/>
         /// </param>
         /// <param name="sortable"></param>
-        public FullTextType(string fieldName, ILoggerFactory logger, Analyzer analyzer = null, bool sortable = false)
+        public FullTextType(string fieldName, ILoggerFactory logger, Analyzer? analyzer = null, bool sortable = false)
             : base(fieldName, logger, true)
         {
             _sortable = sortable;
@@ -68,7 +68,7 @@ namespace Examine.Lucene.Indexing
         /// <summary>
         /// Can be sorted by a concatenated field name since to be sortable it cannot be analyzed
         /// </summary>
-        public override string SortableFieldName => _sortable ? ExamineFieldNames.SortedFieldNamePrefix + FieldName : null;
+        public override string? SortableFieldName => _sortable ? ExamineFieldNames.SortedFieldNamePrefix + FieldName : null;
 
         /// <inheritdoc/>
         public override Analyzer Analyzer => _analyzer;
@@ -103,7 +103,7 @@ namespace Examine.Lucene.Indexing
         /// <param name="query"></param>
         /// <param name="analyzer"></param>
         /// <returns></returns>
-        public static Query GenerateQuery(string fieldName, string query, Analyzer analyzer)
+        public static Query? GenerateQuery(string fieldName, string query, Analyzer analyzer)
         {
             if (query == null)
             {
@@ -175,7 +175,7 @@ namespace Examine.Lucene.Indexing
         /// </summary>
         /// <param name="query"></param>
         /// <returns></returns>
-        public override Query GetQuery(string query)
+        public override Query? GetQuery(string query)
         {
             return GenerateQuery(FieldName, query, _analyzer);
         }

--- a/src/Examine.Lucene/Indexing/FullTextType.cs
+++ b/src/Examine.Lucene/Indexing/FullTextType.cs
@@ -40,7 +40,7 @@ namespace Examine.Lucene.Indexing
         /// <param name="analyzer">
         /// Defaults to <see cref="CultureInvariantStandardAnalyzer"/>
         /// </param>
-        public FullTextType(string fieldName, ILoggerFactory logger, bool sortable = false, bool isFacetable = false, Analyzer analyzer = null)
+        public FullTextType(string fieldName, ILoggerFactory logger, bool sortable = false, bool isFacetable = false, Analyzer? analyzer = null)
             : base(fieldName, logger, true)
         {
             _sortable = sortable;

--- a/src/Examine.Lucene/Indexing/GenericAnalyzerFieldValueType.cs
+++ b/src/Examine.Lucene/Indexing/GenericAnalyzerFieldValueType.cs
@@ -26,7 +26,7 @@ namespace Examine.Lucene.Indexing
         /// <summary>
         /// Can be sorted by a concatenated field name since to be sortable it cannot be analyzed
         /// </summary>
-        public override string SortableFieldName => _sortable ? ExamineFieldNames.SortedFieldNamePrefix + FieldName : null;
+        public override string? SortableFieldName => _sortable ? ExamineFieldNames.SortedFieldNamePrefix + FieldName : null;
 
         /// <inheritdoc/>
         public override Analyzer Analyzer => _analyzer;

--- a/src/Examine.Lucene/Indexing/IIndexFieldValueType.cs
+++ b/src/Examine.Lucene/Indexing/IIndexFieldValueType.cs
@@ -19,7 +19,7 @@ namespace Examine.Lucene.Indexing
         /// Returns the sortable field name or null if the value isn't sortable
         /// </summary>
         /// <remarks>By default it will not be sortable</remarks>
-        string SortableFieldName { get; }
+        string? SortableFieldName { get; }
 
         /// <summary>
         /// Should the value be stored
@@ -29,21 +29,21 @@ namespace Examine.Lucene.Indexing
         /// <summary>
         /// Returns the analyzer for this field type, or null to use the default
         /// </summary>
-        Analyzer Analyzer { get; }
+        Analyzer? Analyzer { get; }
 
         /// <summary>
         /// Adds a value to the document
         /// </summary>
         /// <param name="doc"></param>
         /// <param name="value"></param>
-        void AddValue(Document doc, object value);
+        void AddValue(Document doc, object? value);
 
         /// <summary>
         /// Gets a query as <see cref="Query"/>
         /// </summary>
         /// <param name="query"></param>
         /// <returns></returns>
-        Query GetQuery(string query);
+        Query? GetQuery(string query);
 
         //IHighlighter GetHighlighter(Query query, Searcher searcher, FacetsLoader facetsLoader);
 

--- a/src/Examine.Lucene/Indexing/Int32Type.cs
+++ b/src/Examine.Lucene/Indexing/Int32Type.cs
@@ -52,7 +52,7 @@ namespace Examine.Lucene.Indexing
         }
 
         /// <inheritdoc/>
-        public override Query GetQuery(string query)
+        public override Query? GetQuery(string query)
         {
             return !TryConvert(query, out int parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }

--- a/src/Examine.Lucene/Indexing/Int64Type.cs
+++ b/src/Examine.Lucene/Indexing/Int64Type.cs
@@ -52,7 +52,7 @@ namespace Examine.Lucene.Indexing
         }
 
         /// <inheritdoc/>
-        public override Query GetQuery(string query)
+        public override Query? GetQuery(string query)
         {
             return !TryConvert(query, out long parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }

--- a/src/Examine.Lucene/Indexing/SingleType.cs
+++ b/src/Examine.Lucene/Indexing/SingleType.cs
@@ -52,7 +52,7 @@ namespace Examine.Lucene.Indexing
         }
 
         /// <inheritdoc/>
-        public override Query GetQuery(string query)
+        public override Query? GetQuery(string query)
         {
             return !TryConvert(query, out float parsedVal) ? null : GetQuery(parsedVal, parsedVal);
         }

--- a/src/Examine.Lucene/LuceneDirectoryIndexOptions.cs
+++ b/src/Examine.Lucene/LuceneDirectoryIndexOptions.cs
@@ -12,7 +12,7 @@ namespace Examine.Lucene
         /// <summary>
         /// Returns the directory factory to use
         /// </summary>
-        public IDirectoryFactory DirectoryFactory { get; set; }
+        public IDirectoryFactory? DirectoryFactory { get; set; }
 
         /// <summary>
         /// If true will force unlock the index on startup

--- a/src/Examine.Lucene/LuceneIndexOptions.cs
+++ b/src/Examine.Lucene/LuceneIndexOptions.cs
@@ -16,12 +16,12 @@ namespace Examine.Lucene
         /// <summary>
         /// THe index deletion policy
         /// </summary>
-        public IndexDeletionPolicy IndexDeletionPolicy { get; set; }
+        public IndexDeletionPolicy? IndexDeletionPolicy { get; set; }
 
         /// <summary>
         /// The analyzer used in the index
         /// </summary>
-        public Analyzer Analyzer { get; set; }
+        public Analyzer? Analyzer { get; set; }
 
         /// <summary>
         /// Records per-dimension configuration.  By default a
@@ -36,6 +36,6 @@ namespace Examine.Lucene
         /// Specifies the index value types to use for this indexer, if this is not specified then the result of <see cref="ValueTypeFactoryCollection.GetDefaultValueTypes"/> will be used.
         /// This is generally used to initialize any custom value types for your indexer since the value type collection cannot be modified at runtime.
         /// </summary>
-        public IReadOnlyDictionary<string, IFieldValueTypeFactory> IndexValueTypesFactory { get; set; }
+        public IReadOnlyDictionary<string, IFieldValueTypeFactory>? IndexValueTypesFactory { get; set; }
     }
 }

--- a/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
@@ -41,7 +41,7 @@ namespace Examine.Lucene.Providers
         public abstract ISearchContext GetSearchContext();
 
         /// <inheritdoc />
-		public override IQuery CreateQuery(string category = null, BooleanOperation defaultOperation = BooleanOperation.And)
+		public override IQuery CreateQuery(string? category = null, BooleanOperation defaultOperation = BooleanOperation.And)
             => CreateQuery(category, defaultOperation, LuceneAnalyzer, new LuceneSearchOptions());
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Examine.Lucene.Providers
         /// <param name="luceneAnalyzer"></param>
         /// <param name="searchOptions"></param>
         /// <returns></returns>
-        public IQuery CreateQuery(string category, BooleanOperation defaultOperation, Analyzer luceneAnalyzer, LuceneSearchOptions searchOptions)
+        public IQuery CreateQuery(string? category, BooleanOperation defaultOperation, Analyzer luceneAnalyzer, LuceneSearchOptions searchOptions)
         {
             if (luceneAnalyzer == null)
                 throw new ArgumentNullException(nameof(luceneAnalyzer));
@@ -61,7 +61,7 @@ namespace Examine.Lucene.Providers
         }
 
         /// <inheritdoc />
-        public override ISearchResults Search(string searchText, QueryOptions options = null)
+        public override ISearchResults Search(string searchText, QueryOptions? options = null)
         {
             var sc = CreateQuery().ManagedQuery(searchText);
             return sc.Execute(options);

--- a/src/Examine.Lucene/Providers/MultiIndexSearcher.cs
+++ b/src/Examine.Lucene/Providers/MultiIndexSearcher.cs
@@ -23,7 +23,7 @@ namespace Examine.Lucene.Providers
         /// <param name="indexes"></param>
         /// <param name="facetsConfig">Get the current <see cref="FacetsConfig"/> by injecting <see cref="LuceneIndexOptions.FacetsConfig"/> or use <code>new FacetsConfig()</code> for an empty configuration</param>
         /// <param name="analyzer"></param>
-        public MultiIndexSearcher(string name, IEnumerable<IIndex> indexes, FacetsConfig facetsConfig, Analyzer analyzer = null)
+        public MultiIndexSearcher(string name, IEnumerable<IIndex> indexes, FacetsConfig facetsConfig, Analyzer? analyzer = null)
             : base(name, analyzer ?? new StandardAnalyzer(LuceneInfo.CurrentVersion), facetsConfig)
         {
             _searchers = new Lazy<IEnumerable<ISearcher>>(() => indexes.Select(x => x.Searcher));
@@ -36,7 +36,7 @@ namespace Examine.Lucene.Providers
         /// <param name="searchers"></param>
         /// <param name="facetsConfig">Get the current <see cref="FacetsConfig"/> by injecting <see cref="LuceneIndexOptions.FacetsConfig"/> or use <code>new FacetsConfig()</code> for an empty configuration</param>
         /// <param name="analyzer"></param>
-        public MultiIndexSearcher(string name, Lazy<IEnumerable<ISearcher>> searchers, FacetsConfig facetsConfig, Analyzer analyzer = null)
+        public MultiIndexSearcher(string name, Lazy<IEnumerable<ISearcher>> searchers, FacetsConfig facetsConfig, Analyzer? analyzer = null)
             : base(name, analyzer ?? new StandardAnalyzer(LuceneInfo.CurrentVersion), facetsConfig)
         {
             _searchers = searchers;

--- a/src/Examine.Lucene/Search/FacetFullTextField.cs
+++ b/src/Examine.Lucene/Search/FacetFullTextField.cs
@@ -29,13 +29,13 @@ namespace Examine.Lucene.Search
         /// <summary>
         /// Path hierachy
         /// </summary>
-        public string[] Path { get; internal set; }
+        public string[]? Path { get; internal set; }
 
         /// <inheritdoc/>
         public bool IsTaxonomyIndexed { get; }
 
         /// <inheritdoc/>
-        public FacetFullTextField(string field, string[] values, string facetField, int maxCount = 10, string[] path = null, bool isTaxonomyIndexed = false)
+        public FacetFullTextField(string field, string[] values, string facetField, int maxCount = 10, string[]? path = null, bool isTaxonomyIndexed = false)
         {
             Field = field;
             Values = values;

--- a/src/Examine.Lucene/Search/ISearchContext.cs
+++ b/src/Examine.Lucene/Search/ISearchContext.cs
@@ -24,6 +24,6 @@ namespace Examine.Lucene.Search
         /// </summary>
         /// <param name="fieldName"></param>
         /// <returns></returns>
-        IIndexFieldValueType GetFieldValueType(string fieldName);
+        IIndexFieldValueType? GetFieldValueType(string fieldName);
     }
 }

--- a/src/Examine.Lucene/Search/LateBoundQuery.cs
+++ b/src/Examine.Lucene/Search/LateBoundQuery.cs
@@ -13,7 +13,7 @@ namespace Examine.Lucene.Search
     {
         private readonly Func<Query> _factory;
 
-        private Query _wrapped;
+        private Query? _wrapped;
 
         /// <summary>
         /// The wrapped query
@@ -27,13 +27,13 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc/>
-        public override object Clone()
+        public override object? Clone()
         {
             return Wrapped.Clone();
         }
 
         /// <inheritdoc/>
-        public override Weight CreateWeight(IndexSearcher searcher)
+        public override Weight? CreateWeight(IndexSearcher searcher)
         {
             return Wrapped.CreateWeight(searcher);
         }
@@ -60,13 +60,13 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc/>
-        public override Query Rewrite(IndexReader reader)
+        public override Query? Rewrite(IndexReader reader)
         {
             return Wrapped.Rewrite(reader);
         }
 
         /// <inheritdoc/>
-        public override string ToString(string field)
+        public override string? ToString(string field)
         {
             return Wrapped.ToString(field);
         }

--- a/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
@@ -47,7 +47,7 @@ namespace Examine.Lucene.Search
         #endregion
 
         /// <inheritdoc/>
-        public override ISearchResults Execute(QueryOptions options = null) => _search.Execute(options);
+        public override ISearchResults Execute(QueryOptions? options = null) => _search.Execute(options);
 
         #region IOrdering
 

--- a/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
@@ -119,7 +119,7 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc/>
-        public abstract ISearchResults Execute(QueryOptions options = null);
+        public abstract ISearchResults Execute(QueryOptions? options = null);
 
         /// <inheritdoc/>
         public abstract IOrdering OrderBy(params SortableField[] fields);

--- a/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
@@ -8,7 +8,7 @@ namespace Examine.Lucene.Search
     public class LuceneFacetExtractionContext : IFacetExtractionContext
     {
 
-        private SortedSetDocValuesReaderState _sortedSetReaderState = null;
+        private SortedSetDocValuesReaderState? _sortedSetReaderState = null;
 
         /// <inheritdoc/>
         public LuceneFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcherReference, FacetsConfig facetConfig)

--- a/src/Examine.Lucene/Search/LuceneFacetOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetOperation.cs
@@ -23,13 +23,13 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc/>
-        public ISearchResults Execute(QueryOptions options = null) => _search.Execute(options);
+        public ISearchResults Execute(QueryOptions? options = null) => _search.Execute(options);
 
         /// <inheritdoc/>
-        public IFacetOperations Facet(string field, Action<IFacetQueryField> facetConfiguration = null) => _search.FacetInternal(field, facetConfiguration, Array.Empty<string>());
+        public IFacetOperations Facet(string field, Action<IFacetQueryField>? facetConfiguration = null) => _search.FacetInternal(field, facetConfiguration, Array.Empty<string>());
 
         /// <inheritdoc/>
-        public IFacetOperations Facet(string field, Action<IFacetQueryField> facetConfiguration = null, params string[] values) => _search.FacetInternal(field, facetConfiguration, values);
+        public IFacetOperations Facet(string field, Action<IFacetQueryField>? facetConfiguration = null, params string[] values) => _search.FacetInternal(field, facetConfiguration, values);
 
         /// <inheritdoc/>
         public IFacetOperations Facet(string field, params DoubleRange[] doubleRanges) => _search.FacetInternal(field, doubleRanges);

--- a/src/Examine.Lucene/Search/LuceneQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneQuery.cs
@@ -68,7 +68,7 @@ namespace Examine.Lucene.Search
         public IOrdering All() => _search.All();
 
         /// <inheritdoc/>
-        public IBooleanOperation ManagedQuery(string query, string[] fields = null) 
+        public IBooleanOperation ManagedQuery(string query, string[]? fields = null) 
             => _search.ManagedQueryInternal(query, fields, _occurrence);
 
         /// <inheritdoc/>
@@ -78,7 +78,7 @@ namespace Examine.Lucene.Search
         /// <summary>
         /// The category of the query
         /// </summary>
-        public string Category => _search.Category;
+        public string? Category => _search.Category;
 
         /// <inheritdoc/>
         public IBooleanOperation NativeQuery(string query) => _search.NativeQuery(query);
@@ -131,7 +131,7 @@ namespace Examine.Lucene.Search
             => _search.GroupedNotInternal(fields.ToArray(), query);
 
         /// <inheritdoc/>
-        INestedBooleanOperation INestedQuery.ManagedQuery(string query, string[] fields) 
+        INestedBooleanOperation INestedQuery.ManagedQuery(string query, string[]? fields) 
             => _search.ManagedQueryInternal(query, fields, _occurrence);
 
         /// <inheritdoc/>

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -26,7 +26,7 @@ namespace Examine.Lucene.Search
         private int? _maxDoc;
         private readonly FacetsConfig _facetsConfig;
 
-        internal LuceneSearchExecutor(QueryOptions? options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext, ISet<string> fieldsToLoad, IEnumerable<IFacetField> facetFields, FacetsConfig facetsConfig)
+        internal LuceneSearchExecutor(QueryOptions? options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext, ISet<string>? fieldsToLoad, IEnumerable<IFacetField> facetFields, FacetsConfig facetsConfig)
         {
             _options = options ?? QueryOptions.Default;
             _luceneQuery = query ?? throw new ArgumentNullException(nameof(query));

--- a/src/Examine.Lucene/Search/LuceneSearchOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchOptions.cs
@@ -43,7 +43,7 @@ namespace Examine.Lucene.Search
         /// rewriting and the above points are not relevant then use this change the rewrite
         /// method.
         /// </summary>
-        public MultiTermQuery.RewriteMethod MultiTermRewriteMethod { get; set; }
+        public MultiTermQuery.RewriteMethod? MultiTermRewriteMethod { get; set; }
 
         /// <summary>
         /// Get or Set the prefix length for fuzzy queries. Default is 0.
@@ -53,12 +53,12 @@ namespace Examine.Lucene.Search
         /// <summary>
         /// Get or Set locale used by date range parsing.
         /// </summary>
-        public CultureInfo Locale { get; set; }
+        public CultureInfo? Locale { get; set; }
 
         /// <summary>
         /// Gets or Sets the time zone.
         /// </summary>
-        public TimeZoneInfo TimeZone { get; set; }
+        public TimeZoneInfo? TimeZone { get; set; }
 
         /// <summary>
         /// Gets or Sets the default slop for phrases. If zero, then exact phrase matches

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -18,13 +18,13 @@ namespace Examine.Lucene.Search
     {
         private readonly ISearchContext _searchContext;
         private readonly FacetsConfig _facetsConfig;
-        private ISet<string> _fieldsToLoad = null;
+        private ISet<string>? _fieldsToLoad = null;
         private readonly IList<IFacetField> _facetFields = new List<IFacetField>();
 
         /// <inheritdoc/>
         public LuceneSearchQuery(
             ISearchContext searchContext,
-            string category, Analyzer analyzer, LuceneSearchOptions searchOptions, BooleanOperation occurance, FacetsConfig facetsConfig)
+            string? category, Analyzer analyzer, LuceneSearchOptions searchOptions, BooleanOperation occurance, FacetsConfig facetsConfig)
             : base(CreateQueryParser(searchContext, analyzer, searchOptions), category, searchOptions, occurance)
         {   
             _searchContext = searchContext;
@@ -101,7 +101,7 @@ namespace Examine.Lucene.Search
             => RangeQueryInternal<T>(new[] { fieldName }, fieldValue, fieldValue, true, true, Occurrence);
 
         /// <inheritdoc/>
-        public override IBooleanOperation ManagedQuery(string query, string[] fields = null)
+        public override IBooleanOperation ManagedQuery(string query, string[]? fields = null)
             => ManagedQueryInternal(query, fields, Occurrence);
 
         /// <inheritdoc/>
@@ -113,21 +113,21 @@ namespace Examine.Lucene.Search
             => RangeQueryInternal<T>(new[] { fieldName }, fieldValue, fieldValue, true, true, Occurrence);
 
         /// <inheritdoc/>
-        protected override INestedBooleanOperation ManagedQueryNested(string query, string[] fields = null)
+        protected override INestedBooleanOperation ManagedQueryNested(string query, string[]? fields = null)
             => ManagedQueryInternal(query, fields, Occurrence);
 
         /// <inheritdoc/>
         protected override INestedBooleanOperation RangeQueryNested<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true)
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
-        internal LuceneBooleanOperationBase ManagedQueryInternal(string query, string[] fields, Occur occurance)
+        internal LuceneBooleanOperationBase ManagedQueryInternal(string query, string[]? fields, Occur occurance)
         {
             Query.Add(new LateBoundQuery(() =>
             {
                 //if no fields are specified then use all fields
                 fields = fields ?? AllFields;
 
-                var types = fields.Select(f => _searchContext.GetFieldValueType(f)).Where(t => t != null);
+                var types = fields.Select(f => _searchContext.GetFieldValueType(f)).OfType<IIndexFieldValueType>();
 
                 //Strangely we need an inner and outer query. If we don't do this then the lucene syntax returned is incorrect 
                 //since it doesn't wrap in parenthesis properly. I'm unsure if this is a lucene issue (assume so) since that is what
@@ -213,12 +213,12 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc />
-        public ISearchResults Execute(QueryOptions options = null) => Search(options);
+        public ISearchResults Execute(QueryOptions? options = null) => Search(options);
 
         /// <summary>
         /// Performs a search with a maximum number of results
         /// </summary>
-        private ISearchResults Search(QueryOptions options)
+        private ISearchResults Search(QueryOptions? options)
         {
             // capture local
             var query = Query;

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -338,7 +338,7 @@ namespace Examine.Lucene.Search
         /// <returns></returns>
         protected override LuceneBooleanOperationBase CreateOp() => new LuceneBooleanOperation(this);
 
-        internal IFacetOperations FacetInternal(string field, Action<IFacetQueryField> facetConfiguration, params string[] values)
+        internal IFacetOperations FacetInternal(string field, Action<IFacetQueryField>? facetConfiguration, params string[] values)
         {
             if(values == null)
             {

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -41,7 +41,7 @@ namespace Examine.Lucene.Search
 
         /// <inheritdoc/>
         protected LuceneSearchQueryBase(CustomMultiFieldQueryParser queryParser,
-            string category, LuceneSearchOptions searchOptions, BooleanOperation occurance)
+            string? category, LuceneSearchOptions searchOptions, BooleanOperation occurance)
         {
             Category = category;
             SearchOptions = searchOptions;
@@ -72,7 +72,7 @@ namespace Examine.Lucene.Search
         /// <summary>
         /// The category of the query
         /// </summary>
-        public string Category { get; }
+        public string? Category { get; }
 
         /// <summary>
         /// All the searchable fields of the query
@@ -125,7 +125,7 @@ namespace Examine.Lucene.Search
         public abstract IBooleanOperation Field<T>(string fieldName, T fieldValue) where T : struct;
 
         /// <inheritdoc/>
-        public abstract IBooleanOperation ManagedQuery(string query, string[] fields = null);
+        public abstract IBooleanOperation ManagedQuery(string query, string[]? fields = null);
 
         /// <inheritdoc/>
         public abstract IBooleanOperation RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true) where T : struct;
@@ -140,10 +140,10 @@ namespace Examine.Lucene.Search
 
         /// <inheritdoc/>
         public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params string[] query)
-            => GroupedAnd(fields, query?.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
+            => GroupedAnd(fields, query.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
         /// <inheritdoc/>
-        public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params IExamineValue[] fieldVals)
+        public IBooleanOperation GroupedAnd(IEnumerable<string> fields, params IExamineValue[]? fieldVals)
         {
             if (fields == null)
                 throw new ArgumentNullException(nameof(fields));
@@ -158,7 +158,7 @@ namespace Examine.Lucene.Search
             => GroupedOr(fields, query?.Select(f => new ExamineValue(Examineness.Explicit, f)).Cast<IExamineValue>().ToArray());
 
         /// <inheritdoc/>
-        public IBooleanOperation GroupedOr(IEnumerable<string> fields, params IExamineValue[] query)
+        public IBooleanOperation GroupedOr(IEnumerable<string> fields, params IExamineValue[]? query)
         {
             if (fields == null)
                 throw new ArgumentNullException(nameof(fields));
@@ -202,7 +202,7 @@ namespace Examine.Lucene.Search
         /// <param name="query"></param>
         /// <param name="fields"></param>
         /// <returns></returns>
-        protected abstract INestedBooleanOperation ManagedQueryNested(string query, string[] fields = null);
+        protected abstract INestedBooleanOperation ManagedQueryNested(string query, string[]? fields = null);
 
         /// <summary>
         /// Matches items as defined by the IIndexFieldValueType used for the fields specified. 
@@ -241,7 +241,7 @@ namespace Examine.Lucene.Search
         INestedBooleanOperation INestedQuery.GroupedNot(IEnumerable<string> fields, params IExamineValue[] query)
             => GroupedNotInternal(fields == null ? s_emptyStringArray : fields.ToArray(), query);
 
-        INestedBooleanOperation INestedQuery.ManagedQuery(string query, string[] fields) => ManagedQueryNested(query, fields);
+        INestedBooleanOperation INestedQuery.ManagedQuery(string query, string[]? fields) => ManagedQueryNested(query, fields);
 
         INestedBooleanOperation INestedQuery.RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive, bool maxInclusive)
             => RangeQueryNested(fields, min, max, minInclusive, maxInclusive);
@@ -274,7 +274,7 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc/>
-        protected internal LuceneBooleanOperationBase GroupedAndInternal(string[] fields, IExamineValue[] fieldVals, Occur occurrence)
+        protected internal LuceneBooleanOperationBase GroupedAndInternal(string[] fields, IExamineValue[]? fieldVals, Occur occurrence)
         {
             if (fields == null)
                 throw new ArgumentNullException(nameof(fields));
@@ -327,7 +327,7 @@ namespace Examine.Lucene.Search
         }
 
         /// <inheritdoc/>
-        protected internal LuceneBooleanOperationBase GroupedOrInternal(string[] fields, IExamineValue[] fieldVals, Occur occurrence)
+        protected internal LuceneBooleanOperationBase GroupedOrInternal(string[] fields, IExamineValue[]? fieldVals, Occur occurrence)
         {
             if (fields == null)
                 throw new ArgumentNullException(nameof(fields));
@@ -409,10 +409,10 @@ namespace Examine.Lucene.Search
                     if (useQueryParser)
                     {
                         queryToAdd = _queryParser.GetFieldQueryInternal(fieldName, fieldValue.Value);
-                        if (queryToAdd != null)
-                        { 
+                        //if (queryToAdd != null) // TODO: Does this ever happen? Then the method should be made with a nullable return
+                        //{
                             queryToAdd.Boost = fieldValue.Level;
-                        }
+                        //}
                     }
                     else
                     {
@@ -422,7 +422,7 @@ namespace Examine.Lucene.Search
                     }
                     break;
                 case Examineness.Proximity:
-                    int proximity = Convert.ToInt32(fieldValue.Level);                    
+                    int proximity = Convert.ToInt32(fieldValue.Level);
                     if (useQueryParser)
                     {
                         queryToAdd = _queryParser.GetProximityQueryInternal(fieldName, fieldValue.Value, proximity);

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Examine.Search;
 using Lucene.Net.Facet.Range;
@@ -265,7 +266,7 @@ namespace Examine.Lucene.Search
         /// <inheritdoc/>
         private LuceneBooleanOperationBase FieldInternal(string fieldName, IExamineValue fieldValue, Occur occurrence, bool useQueryParser)
         {
-            Query queryToAdd = GetFieldInternalQuery(fieldName, fieldValue, useQueryParser);
+            Query? queryToAdd = GetFieldInternalQuery(fieldName, fieldValue, useQueryParser);
 
             if (queryToAdd != null)
                 Query.Add(queryToAdd, occurrence);
@@ -364,7 +365,7 @@ namespace Examine.Lucene.Search
         /// <param name="fieldValue"></param>
         /// <param name="useQueryParser">True to use the query parser to parse the search text, otherwise, manually create the queries</param>
         /// <returns>A new <see cref="IBooleanOperation"/> with the clause appended</returns>
-        protected virtual Query GetFieldInternalQuery(string fieldName, IExamineValue fieldValue, bool useQueryParser)
+        protected virtual Query? GetFieldInternalQuery(string fieldName, IExamineValue fieldValue, bool useQueryParser)
         {
             if (string.IsNullOrEmpty(fieldName))
                 throw new ArgumentException($"'{nameof(fieldName)}' cannot be null or empty", nameof(fieldName));
@@ -373,7 +374,7 @@ namespace Examine.Lucene.Search
             if (string.IsNullOrEmpty(fieldValue.Value))
                 throw new ArgumentException($"'{nameof(fieldName)}' cannot be null or empty", nameof(fieldName));
 
-            Query queryToAdd;
+            Query? queryToAdd;
 
             switch (fieldValue.Examineness)
             {
@@ -409,10 +410,10 @@ namespace Examine.Lucene.Search
                     if (useQueryParser)
                     {
                         queryToAdd = _queryParser.GetFieldQueryInternal(fieldName, fieldValue.Value);
-                        //if (queryToAdd != null) // TODO: Does this ever happen? Then the method should be made with a nullable return
-                        //{
+                        if (queryToAdd != null)
+                        {
                             queryToAdd.Boost = fieldValue.Level;
-                        //}
+                        }
                     }
                     else
                     {

--- a/src/Examine.Lucene/Search/MultiSearchContext.cs
+++ b/src/Examine.Lucene/Search/MultiSearchContext.cs
@@ -11,7 +11,7 @@ namespace Examine.Lucene.Search
     {
         private readonly ISearchContext[] _inner;
         
-        private string[] _fields;
+        private string[]? _fields;
 
         /// <inheritdoc/>
         public MultiSearchContext(ISearchContext[] inner) => _inner = inner;
@@ -24,7 +24,7 @@ namespace Examine.Lucene.Search
         public string[] SearchableFields => _fields ?? (_fields = _inner.SelectMany(x => x.SearchableFields).Distinct().ToArray());
 
         /// <inheritdoc/>
-        public IIndexFieldValueType GetFieldValueType(string fieldName)
+        public IIndexFieldValueType? GetFieldValueType(string fieldName)
             => _inner.Select(cc => cc.GetFieldValueType(fieldName)).FirstOrDefault(type => type != null);
 
     }

--- a/src/Examine.Lucene/Search/MultiSearchSearcherReference.cs
+++ b/src/Examine.Lucene/Search/MultiSearchSearcherReference.cs
@@ -12,7 +12,7 @@ namespace Examine.Lucene.Search
         public MultiSearchSearcherReference(ISearcherReference[] inner) => _inner = inner;
 
         private bool _disposedValue;
-        private IndexSearcher _searcher;
+        private IndexSearcher? _searcher;
         private readonly ISearcherReference[] _inner;
 
         /// <inheritdoc/>

--- a/src/Examine.Lucene/Search/SearchContext.cs
+++ b/src/Examine.Lucene/Search/SearchContext.cs
@@ -13,7 +13,7 @@ namespace Examine.Lucene.Search
     {
         private readonly SearcherManager _searcherManager;
         private readonly FieldValueTypeCollection _fieldValueTypeCollection;
-        private string[] _searchableFields;
+        private string[]? _searchableFields;
 
         /// <inheritdoc/>
         public SearchContext(SearcherManager searcherManager, FieldValueTypeCollection fieldValueTypeCollection)

--- a/src/Examine.Lucene/Search/SearcherReference.cs
+++ b/src/Examine.Lucene/Search/SearcherReference.cs
@@ -8,7 +8,7 @@ namespace Examine.Lucene.Search
     {
         private bool _disposedValue;
         private readonly SearcherManager _searcherManager;
-        private IndexSearcher _searcher;
+        private IndexSearcher? _searcher;
 
         /// <inheritdoc/>
         public SearcherReference(SearcherManager searcherManager)

--- a/src/Examine.Lucene/ValueTypeFactoryCollection.cs
+++ b/src/Examine.Lucene/ValueTypeFactoryCollection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Examine.Lucene.Analyzers;
 using Examine.Lucene.Indexing;
@@ -33,7 +34,11 @@ namespace Examine.Lucene
         /// <param name="valueTypeName"></param>
         /// <param name="fieldValueTypeFactory"></param>
         /// <returns></returns>
-        public bool TryGetFactory(string valueTypeName, out IFieldValueTypeFactory fieldValueTypeFactory)
+        public bool TryGetFactory(string valueTypeName,
+#if !NETSTANDARD2_0
+            [MaybeNullWhen(false)]
+#endif
+            out IFieldValueTypeFactory fieldValueTypeFactory)
             => _valueTypeFactories.TryGetValue(valueTypeName, out fieldValueTypeFactory);
 
         /// <summary>
@@ -61,7 +66,7 @@ namespace Examine.Lucene
         public static IReadOnlyDictionary<string, IFieldValueTypeFactory> GetDefaultValueTypes(ILoggerFactory loggerFactory, Analyzer defaultAnalyzer)
             => GetDefaults(loggerFactory, defaultAnalyzer).ToDictionary(x => x.Key, x => (IFieldValueTypeFactory)new DelegateFieldValueTypeFactory(x.Value));
 
-        private static IReadOnlyDictionary<string, Func<string, IIndexFieldValueType>> GetDefaults(ILoggerFactory loggerFactory, Analyzer defaultAnalyzer = null) =>
+        private static IReadOnlyDictionary<string, Func<string, IIndexFieldValueType>> GetDefaults(ILoggerFactory loggerFactory, Analyzer? defaultAnalyzer = null) =>
             new Dictionary<string, Func<string, IIndexFieldValueType>>(StringComparer.InvariantCultureIgnoreCase) //case insensitive
             {
                 {"number", name => new Int32Type(name, loggerFactory)},

--- a/src/Examine.Test/ExamineBaseTest.cs
+++ b/src/Examine.Test/ExamineBaseTest.cs
@@ -21,7 +21,7 @@ namespace Examine.Test
             loggerFactory.CreateLogger(typeof(ExamineBaseTest)).LogDebug("Initializing test");
         }
 
-        public TestIndex GetTestIndex(Directory d, Analyzer analyzer, FieldDefinitionCollection fieldDefinitions = null, IndexDeletionPolicy indexDeletionPolicy = null, IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null, FacetsConfig? facetsConfig = null)
+        public TestIndex GetTestIndex(Directory d, Analyzer analyzer, FieldDefinitionCollection? fieldDefinitions = null, IndexDeletionPolicy? indexDeletionPolicy = null, IReadOnlyDictionary<string, IFieldValueTypeFactory>? indexValueTypesFactory = null, FacetsConfig? facetsConfig = null)
         {
             var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
             return new TestIndex(

--- a/src/Examine.Test/ExamineBaseTest.cs
+++ b/src/Examine.Test/ExamineBaseTest.cs
@@ -21,7 +21,7 @@ namespace Examine.Test
             loggerFactory.CreateLogger(typeof(ExamineBaseTest)).LogDebug("Initializing test");
         }
 
-        public TestIndex GetTestIndex(Directory d, Analyzer analyzer, FieldDefinitionCollection? fieldDefinitions = null, IndexDeletionPolicy? indexDeletionPolicy = null, IReadOnlyDictionary<string, IFieldValueTypeFactory>? indexValueTypesFactory = null, FacetsConfig? facetsConfig = null)
+        public TestIndex GetTestIndex(Directory d, Analyzer analyzer, FieldDefinitionCollection fieldDefinitions = null, IndexDeletionPolicy indexDeletionPolicy = null, IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null, FacetsConfig facetsConfig = null)
         {
             var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
             return new TestIndex(


### PR DESCRIPTION
This adds the nullable feature to Examine and the Facets feature. This means that this PR is a super set of #311 and should be merged after the facets feature. This is PR also includes the changes in #307 which adds multitargeting which is necessary to support nullable.

To see the changes in this PR before merging #311 and #307 see [this commit](https://github.com/Shazwazza/Examine/commit/ebeff827376531a7220ce59e46dd15e883db041f)

## What changed

- Added `<Nullable>enable</Nullable>` to add the nullable feature
- Added ` <LangVersion>9</LangVersion>` to support some of the more useful nullable features
- Disabled nullable warnings in `netstandard2.0` - This version doesn't support nullable that well and it's way easier to omit the warnings. The nullable features that `netstandard2.0` have will also be included without fixing the warnings and these features will also be correct when fixing similar places with the warnings from `netstandard2.1` and `net6.0`
```
<!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->
  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
    <NoWarn>$(NoWarn);nullable</NoWarn>
  </PropertyGroup>
```
- Added so many question marks

## Approch

This PR does it's best to add the nullable feature without changing any logic, therefore, if a property was able to be null it's been marked that way.

## TODOs

Some places in the code can't comply with the nullable feature without changing the code behaviour (I would like help deciding what to do with these. It doesn't have to be part of this PR):

**Note: The tasks can be found with an attached `// TODO:` marker in the PR code**

- [x] `src/Examine.Core/OrderedDictionary.cs` - `TVal IDictionary<TKey, TVal>.this[TKey key]` It's common for this to throw if the key is not found but this returns null instead.
- [ ] `src/Examine.Lucene/Providers/LuceneIndex.cs` - `public TrackingIndexWriter IndexWriter` Here it's possiable for `_writer` to be null. Maybe we should throw if this happens?
- [x] `src/Examine.Lucene/Search/LuceneSearchQueryBase.cs` - `protected virtual Query GetFieldInternalQuery(string fieldName, IExamineValue fieldValue, bool useQueryParser)` Here a null check in one of the cases tells the compiler that this value can be null at some point. If this is the case then the methods relevant for setting this value should be marks as possiable to return null.