### PR TITLE
fix: Let FSDirectory choose an implementation

### DIFF
--- a/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs
@@ -23,7 +23,7 @@ namespace Examine.Lucene.Directories
             var path = Path.Combine(_baseDir.FullName, luceneIndex.Name);
             var luceneIndexFolder = new DirectoryInfo(path);
 
-            var dir = new SimpleFSDirectory(luceneIndexFolder, LockFactory.GetLockFactory(luceneIndexFolder));
+            var dir = FSDirectory.Open(luceneIndexFolder, LockFactory.GetLockFactory(luceneIndexFolder));
             if (forceUnlock)
             {
                 IndexWriter.Unlock(dir);

--- a/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/SyncedFileSystemDirectoryFactory.cs
@@ -76,7 +76,7 @@ namespace Examine.Lucene.Directories
 
             // now create the replicator that will copy from local to main on schedule
             _replicator = new ExamineReplicator(_loggerFactory, luceneIndex, mainDir, tempDir);
-            var localLuceneDir = new SimpleFSDirectory(
+            var localLuceneDir = FSDirectory.Open(
                 localLuceneIndexFolder,
                 LockFactory.GetLockFactory(localLuceneIndexFolder));
 


### PR DESCRIPTION
After reading the XML documentation on `FSDirectory` in Lucene.NET it seems that the most optimal way to determine an implementation is using the `FSDirectory.Open` method. (https://github.com/apache/lucenenet/blob/c0c480409e2d3424fbdcc563426c66cacbf72632/src/Lucene.Net/Store/FSDirectory.cs#L35-L87)

[FSDirectory.Open link](https://github.com/apache/lucenenet/blob/c0c480409e2d3424fbdcc563426c66cacbf72632/src/Lucene.Net/Store/FSDirectory.cs#L133-L158)

Is there any specific reason to choose the `SimpleFSDirectory` always?