### PR TITLE
Support for efficient deep paging in lucene.net

### DIFF
--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -96,6 +96,15 @@ With the combination of `ISearchResult.Skip` and `maxResults`, we can tell Lucen
 * Skip over a certain number of results without allocating them and tell Lucene
 * only allocate a certain number of results after skipping
 
+### Deep Paging
+When using Lucene.NET as the Examine provider it is possible to more efficiently perform deep paging.
+Steps:
+1. Build and Execute your query as normal.
+2. Cast the ISearchResults from IQueryExecutor.Execute to ILuceneSearchResults
+3. Store ILuceneSearchResults.SearchAfter (SearchAfterOptions) for the next page. It may be worth serializing this class and cryptographically hashing it to prevent tampering in a web application so that it can be made available to the next request for the next page.
+4. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip is still relative to the start of the search results.
+5. Repeat Steps 2-4 for each page.
+
 ### Example
 
 ```cs

--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -99,11 +99,12 @@ With the combination of `ISearchResult.Skip` and `maxResults`, we can tell Lucen
 ### Deep Paging
 When using Lucene.NET as the Examine provider it is possible to more efficiently perform deep paging.
 Steps:
-1. Build and Execute your query as normal.
+1. Build and execute your query as normal.
 2. Cast the ISearchResults from IQueryExecutor.Execute to ILuceneSearchResults
 3. Store ILuceneSearchResults.SearchAfter (SearchAfterOptions) for the next page. It may be worth serializing this class and cryptographically hashing it to prevent tampering in a web application so that it can be made available to the next request for the next page.
-4. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip is still relative to the start of the search results.
-5. Repeat Steps 2-4 for each page.
+4. Create the same query as the previous request.
+5. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip is still relative to the start of the search results.
+6. Repeat Steps 2-5 for each page.
 
 ### Example
 

--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -103,7 +103,7 @@ Steps:
 2. Cast the ISearchResults from IQueryExecutor.Execute to ILuceneSearchResults
 3. Store ILuceneSearchResults.SearchAfter (SearchAfterOptions) for the next page. It may be worth serializing this class and cryptographically hashing it to prevent tampering in a web application so that it can be made available to the next request for the next page.
 4. Create the same query as the previous request.
-5. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip is still relative to the start of the search results.
+5. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip will be ignored, the next take documents will be retrieved after the SearchAfterOptions document.
 6. Repeat Steps 2-5 for each page.
 
 ### Example

--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -101,7 +101,7 @@ When using Lucene.NET as the Examine provider it is possible to more efficiently
 Steps:
 1. Build and execute your query as normal.
 2. Cast the ISearchResults from IQueryExecutor.Execute to ILuceneSearchResults
-3. Store ILuceneSearchResults.SearchAfter (SearchAfterOptions) for the next page. It may be worth serializing this class and cryptographically hashing it to prevent tampering in a web application so that it can be made available to the next request for the next page.
+3. Store ILuceneSearchResults.SearchAfter (SearchAfterOptions) for the next page.
 4. Create the same query as the previous request.
 5. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip will be ignored, the next take documents will be retrieved after the SearchAfterOptions document.
 6. Repeat Steps 2-5 for each page.

--- a/src/Examine.Core/EmptySearchResults.cs
+++ b/src/Examine.Core/EmptySearchResults.cs
@@ -24,7 +24,9 @@ namespace Examine
 
 		public long TotalItemCount => 0;
 
-	    public IEnumerable<ISearchResult> Skip(int skip)
+        public string ContinueWith => default;
+
+        public IEnumerable<ISearchResult> Skip(int skip)
 		{
 			return Enumerable.Empty<ISearchResult>();
 		}

--- a/src/Examine.Core/EmptySearchResults.cs
+++ b/src/Examine.Core/EmptySearchResults.cs
@@ -24,7 +24,6 @@ namespace Examine
 
 		public long TotalItemCount => 0;
 
-        public string ContinueWith => default;
 
         public IEnumerable<ISearchResult> Skip(int skip)
 		{

--- a/src/Examine.Core/Search/QueryOptions.cs
+++ b/src/Examine.Core/Search/QueryOptions.cs
@@ -24,7 +24,14 @@ namespace Examine.Search
             Take = take ?? DefaultMaxResults;
         }
 
+        /// <summary>
+        /// The number of documents to skip in the result set.
+        /// </summary>
         public int Skip { get; }
+
+        /// <summary>
+        /// The number of documents to take in the result set.
+        /// </summary>
         public int Take { get; }
     }
 }

--- a/src/Examine.Lucene/Search/ILuceneSearchResults.cs
+++ b/src/Examine.Lucene/Search/ILuceneSearchResults.cs
@@ -1,0 +1,7 @@
+namespace Examine.Lucene.Search
+{
+    public interface ILuceneSearchResults : ISearchResults
+    {
+        SearchAfterOptions SearchAfter { get; }
+    }
+}

--- a/src/Examine.Lucene/Search/ILuceneSearchResults.cs
+++ b/src/Examine.Lucene/Search/ILuceneSearchResults.cs
@@ -1,7 +1,13 @@
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// Lucene.NET Search Results
+    /// </summary>
     public interface ILuceneSearchResults : ISearchResults
     {
+        /// <summary>
+        /// Options for Searching After. Used for efficent deep paging.
+        /// </summary>
         SearchAfterOptions SearchAfter { get; }
     }
 }

--- a/src/Examine.Lucene/Search/ILuceneSearchResults.cs
+++ b/src/Examine.Lucene/Search/ILuceneSearchResults.cs
@@ -9,5 +9,11 @@ namespace Examine.Lucene.Search
         /// Options for Searching After. Used for efficent deep paging.
         /// </summary>
         SearchAfterOptions SearchAfter { get; }
+
+        /// <summary>
+        /// Returns the maximum score value encountered. Note that in case
+        /// scores are not tracked, this returns <see cref="float.NaN"/>.
+        /// </summary>
+        float MaxScore { get; }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneQueryOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneQueryOptions.cs
@@ -1,0 +1,27 @@
+using Examine.Search;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Lucene.NET specific query options
+    /// </summary>
+    public class LuceneQueryOptions : QueryOptions
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="skip">Number of result documents to skip.</param>
+        /// <param name="take">Optional number of result documents to take.</param>
+        /// <param name="searchAfter">Optionally skip to results after the results from the previous search execution. Used for efficent deep paging.</param>
+        public LuceneQueryOptions(int skip, int? take = null, SearchAfterOptions searchAfter = null)
+            : base(skip, take)
+        {
+            SearchAfter = searchAfter;
+        }
+
+        /// <summary>
+        /// Options for Searching After. Used for efficent deep paging.
+        /// </summary>
+        public SearchAfterOptions SearchAfter { get; }
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneQueryOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneQueryOptions.cs
@@ -13,6 +13,8 @@ namespace Examine.Lucene.Search
         /// <param name="skip">Number of result documents to skip.</param>
         /// <param name="take">Optional number of result documents to take.</param>
         /// <param name="searchAfter">Optionally skip to results after the results from the previous search execution. Used for efficent deep paging.</param>
+        /// <param name="trackDocumentMaxScore">Whether to track the maximum document score. For best performance, if not needed, leave false.</param>
+        /// <param name="trackDocumentScores">Whether to Track Document Scores. For best performance, if not needed, leave false.</param>
         public LuceneQueryOptions(int skip, int? take = null, SearchAfterOptions searchAfter = null, bool trackDocumentScores = false, bool trackDocumentMaxScore = false)
             : base(skip, take)
         {

--- a/src/Examine.Lucene/Search/LuceneQueryOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneQueryOptions.cs
@@ -13,11 +13,23 @@ namespace Examine.Lucene.Search
         /// <param name="skip">Number of result documents to skip.</param>
         /// <param name="take">Optional number of result documents to take.</param>
         /// <param name="searchAfter">Optionally skip to results after the results from the previous search execution. Used for efficent deep paging.</param>
-        public LuceneQueryOptions(int skip, int? take = null, SearchAfterOptions searchAfter = null)
+        public LuceneQueryOptions(int skip, int? take = null, SearchAfterOptions searchAfter = null, bool trackDocumentScores = false, bool trackDocumentMaxScore = false)
             : base(skip, take)
         {
+            TrackDocumentScores = trackDocumentScores;
+            TrackDocumentMaxScore = trackDocumentMaxScore;
             SearchAfter = searchAfter;
         }
+
+        /// <summary>
+        /// Whether to Track Document Scores. For best performance, if not needed, leave false.
+        /// </summary>
+        public bool TrackDocumentScores { get; }
+
+        /// <summary>
+        /// Whether to track the maximum document score. For best performance, if not needed, leave false.
+        /// </summary>
+        public bool TrackDocumentMaxScore { get; }
 
         /// <summary>
         /// Options for Searching After. Used for efficent deep paging.

--- a/src/Examine.Lucene/Search/LuceneSearchExtensions.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Examine.Search;
 using Lucene.Net.Search;
 
@@ -49,6 +49,22 @@ namespace Examine.Lucene.Search
             {
                 return BooleanOperation.Or;
             }
+        }
+        /// <summary>
+        /// Executes the query
+        /// </summary>
+        public static ILuceneSearchResults ExecuteWithLucene(this IQueryExecutor queryExecutor, QueryOptions options = null)
+        {
+            if(queryExecutor is LuceneBooleanOperation
+                || queryExecutor is LuceneSearchQuery)
+            {
+                var results = queryExecutor.Execute(options);
+                if(results is ILuceneSearchResults luceneSearchResults)
+                {
+                    return luceneSearchResults;
+                }
+            }
+            throw new NotSupportedException("QueryExecutor is not Lucene.NET");
         }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchResult.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchResult.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Examine.Lucene.Search
+{
+    public class LuceneSearchResult : SearchResult, ISearchResult
+    {
+        public LuceneSearchResult(string id, float score, Func<IDictionary<string, List<string>>> lazyFieldVals, int shardId)
+            : base(id, score, lazyFieldVals)
+        {
+            ShardIndex = shardId;
+        }
+
+        public int ShardIndex { get; }
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneSearchResults.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchResults.cs
@@ -1,22 +1,25 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace Examine.Lucene.Search
 {
-    public class LuceneSearchResults : ISearchResults
+    public class LuceneSearchResults : ILuceneSearchResults
     {
-        public static LuceneSearchResults Empty { get; } = new LuceneSearchResults(Array.Empty<ISearchResult>(), 0);
+        public static LuceneSearchResults Empty { get; } = new LuceneSearchResults(Array.Empty<ISearchResult>(), 0, default);
 
         private readonly IReadOnlyCollection<ISearchResult> _results;
 
-        public LuceneSearchResults(IReadOnlyCollection<ISearchResult> results, int totalItemCount)
+        public LuceneSearchResults(IReadOnlyCollection<ISearchResult> results, int totalItemCount, SearchAfterOptions searchAfterOptions)
         {
             _results = results;
             TotalItemCount = totalItemCount;
+            SearchAfter = searchAfterOptions;
         }
 
         public long TotalItemCount { get; }
+
+        public SearchAfterOptions SearchAfter { get; }
 
         public IEnumerator<ISearchResult> GetEnumerator() => _results.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Examine.Lucene/Search/LuceneSearchResults.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchResults.cs
@@ -6,18 +6,25 @@ namespace Examine.Lucene.Search
 {
     public class LuceneSearchResults : ILuceneSearchResults
     {
-        public static LuceneSearchResults Empty { get; } = new LuceneSearchResults(Array.Empty<ISearchResult>(), 0, default);
+        public static LuceneSearchResults Empty { get; } = new LuceneSearchResults(Array.Empty<ISearchResult>(), 0,float.NaN, default);
 
         private readonly IReadOnlyCollection<ISearchResult> _results;
 
-        public LuceneSearchResults(IReadOnlyCollection<ISearchResult> results, int totalItemCount, SearchAfterOptions searchAfterOptions)
+        public LuceneSearchResults(IReadOnlyCollection<ISearchResult> results, int totalItemCount,float maxScore, SearchAfterOptions searchAfterOptions)
         {
             _results = results;
             TotalItemCount = totalItemCount;
+            MaxScore = maxScore;
             SearchAfter = searchAfterOptions;
         }
 
         public long TotalItemCount { get; }
+
+        /// <summary>
+        /// Returns the maximum score value encountered. Note that in case
+        /// scores are not tracked, this returns <see cref="float.NaN"/>.
+        /// </summary>
+        public float MaxScore { get; }
 
         public SearchAfterOptions SearchAfter { get; }
 

--- a/src/Examine.Lucene/Search/SearchAfterOptions.cs
+++ b/src/Examine.Lucene/Search/SearchAfterOptions.cs
@@ -1,0 +1,39 @@
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Options for Searching After. Used for efficent deep paging.
+    /// </summary>
+    public class SearchAfterOptions
+    {
+
+        public SearchAfterOptions(int documentId, float documentScore, object[] fields, int shardIndex)
+        {
+            DocumentId = documentId;
+            DocumentScore = documentScore;
+            Fields = fields;
+            ShardIndex = shardIndex;
+        }
+
+        /// <summary>
+        /// The Id of the last document in the previous result set.
+        /// The search will search after this document
+        /// </summary>
+        public int DocumentId { get; }
+
+        /// <summary>
+        /// The Score of the last document in the previous result set.
+        /// The search will search after this document
+        /// </summary>
+        public float DocumentScore { get; }
+
+        /// <summary>
+        /// The index of the shard the doc belongs to
+        /// </summary>
+        public int? ShardIndex { get; }
+
+        /// <summary>
+        /// Search fields. Should contain null or J2N.Int
+        /// </summary>
+        public object[] Fields { get; }
+    }
+}

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -56,8 +56,8 @@ namespace Examine.Test.Examine.Lucene.Search
                         }).NativeQuery("*dney"));
 
                 var results1 = query1.Execute();
-                               
-                Assert.AreEqual(2, results1.TotalItemCount);               
+
+                Assert.AreEqual(2, results1.TotalItemCount);
             }
         }
 
@@ -1949,7 +1949,7 @@ namespace Examine.Test.Examine.Lucene.Search
             {
                 for (int i = 0; i < 1000; i++)
                 {
-                    indexer.IndexItems(new[] {ValueSet.FromObject(i.ToString(), "content", new { Content = "hello world" })});
+                    indexer.IndexItems(new[] { ValueSet.FromObject(i.ToString(), "content", new { Content = "hello world" }) });
                 }
 
                 indexer.IndexItems(new[] { ValueSet.FromObject(2000.ToString(), "content", new { Content = "donotfind" }) });
@@ -2490,7 +2490,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var results = sc
                     .Execute(QueryOptions.SkipTake(pageIndex * pageSize, pageSize))
-                    .ToList();                    
+                    .ToList();
                 Assert.AreEqual(2, results.Count);
 
                 pageIndex++;
@@ -2581,7 +2581,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 //Arrange
                 var sc = searcher.CreateQuery("content")
                     .Field("writerName", "administrator")
-                    .OrderByDescending(new SortableField("id",SortType.Int));
+                    .OrderByDescending(new SortableField("id", SortType.Int));
                 var luceneOptions = new LuceneQueryOptions(0, 2);
                 //Act
 
@@ -2590,14 +2590,17 @@ namespace Examine.Test.Examine.Lucene.Search
                 var results = sc.Execute(luceneOptions);
                 var luceneResults = results as ILuceneSearchResults;
                 Assert.IsNotNull(luceneResults);
-                Assert.IsNotNull(luceneResults.SearchAfter,"Search After details should be available");
+                Assert.IsNotNull(luceneResults.SearchAfter, "Search After details should be available");
                 var luceneResults1List = luceneResults.ToList();
                 Assert.IsTrue(luceneResults1List.Any(x => x.Id == "1"));
                 Assert.IsTrue(luceneResults1List.Any(x => x.Id == "2"));
 
                 // Second query result continues after result 1 (zero indexed), Takes 1, should not include any of the results before or include the SearchAfter docid / scoreid
-                var searchAfter = new SearchAfterOptions(luceneResults.SearchAfter.DocumentId, luceneResults.SearchAfter.DocumentScore, luceneResults.SearchAfter.Fields, luceneResults.SearchAfter.ShardIndex.Value);
-                var luceneOptions2 = new LuceneQueryOptions(1,1, searchAfter);
+                var searchAfter = new SearchAfterOptions(luceneResults.SearchAfter.DocumentId,
+                    luceneResults.SearchAfter.DocumentScore,
+                    luceneResults.SearchAfter.Fields,
+                    luceneResults.SearchAfter.ShardIndex.Value);
+                var luceneOptions2 = new LuceneQueryOptions(0, 1, searchAfter);
                 var results2 = sc.Execute(luceneOptions2);
                 var luceneResults2 = results2 as ILuceneSearchResults;
                 var luceneResults2List = luceneResults2.ToList();
@@ -2608,7 +2611,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 // Third query result continues after result 2 (zero indexed), Takes 1
                 var searchAfter2 = new SearchAfterOptions(luceneResults2.SearchAfter.DocumentId, luceneResults2.SearchAfter.DocumentScore, luceneResults2.SearchAfter.Fields, luceneResults2.SearchAfter.ShardIndex.Value);
-                var luceneOptions3 = new LuceneQueryOptions(2, 1, searchAfter2);
+                var luceneOptions3 = new LuceneQueryOptions(0, 1, searchAfter2);
                 var results3 = sc.Execute(luceneOptions3);
                 var luceneResults3 = results3 as ILuceneSearchResults;
                 Assert.IsNotNull(luceneResults3);

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -2557,7 +2557,7 @@ namespace Examine.Test.Examine.Lucene.Search
         }
 
         [Test]
-        public void SearchAfter_Results_Returns_Different_Results()
+        public void SearchAfter_Sorted_Results_Returns_Different_Results()
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             using (var luceneDir = new RandomIdRAMDirectory())
@@ -2582,6 +2582,73 @@ namespace Examine.Test.Examine.Lucene.Search
                 var sc = searcher.CreateQuery("content")
                     .Field("writerName", "administrator")
                     .OrderByDescending(new SortableField("id", SortType.Int));
+                var luceneOptions = new LuceneQueryOptions(0, 2);
+                //Act
+
+                //There are 4 results
+                // First query skips 0 and takes 2.
+                var results = sc.Execute(luceneOptions);
+                var luceneResults = results as ILuceneSearchResults;
+                Assert.IsNotNull(luceneResults);
+                Assert.IsNotNull(luceneResults.SearchAfter, "Search After details should be available");
+                var luceneResults1List = luceneResults.ToList();
+                Assert.IsTrue(luceneResults1List.Any(x => x.Id == "1"));
+                Assert.IsTrue(luceneResults1List.Any(x => x.Id == "2"));
+
+                // Second query result continues after result 1 (zero indexed), Takes 1, should not include any of the results before or include the SearchAfter docid / scoreid
+                var searchAfter = new SearchAfterOptions(luceneResults.SearchAfter.DocumentId,
+                    luceneResults.SearchAfter.DocumentScore,
+                    luceneResults.SearchAfter.Fields,
+                    luceneResults.SearchAfter.ShardIndex.Value);
+                var luceneOptions2 = new LuceneQueryOptions(0, 1, searchAfter);
+                var results2 = sc.Execute(luceneOptions2);
+                var luceneResults2 = results2 as ILuceneSearchResults;
+                var luceneResults2List = luceneResults2.ToList();
+                Assert.IsTrue(luceneResults2List.Any(x => x.Id == "3"), $"Expected to contain next result after docId {luceneResults.SearchAfter.DocumentId}");
+                Assert.IsNotNull(luceneResults2);
+
+                Assert.IsFalse(luceneResults2List.Any(x => luceneResults.ToList().Any(y => y.Id == x.Id)), "Results should not overlap");
+
+                // Third query result continues after result 2 (zero indexed), Takes 1
+                var searchAfter2 = new SearchAfterOptions(luceneResults2.SearchAfter.DocumentId, luceneResults2.SearchAfter.DocumentScore, luceneResults2.SearchAfter.Fields, luceneResults2.SearchAfter.ShardIndex.Value);
+                var luceneOptions3 = new LuceneQueryOptions(0, 1, searchAfter2);
+                var results3 = sc.Execute(luceneOptions3);
+                var luceneResults3 = results3 as ILuceneSearchResults;
+                Assert.IsNotNull(luceneResults3);
+                var luceneResults3List = luceneResults3.ToList();
+                Assert.IsTrue(luceneResults3List.Any(x => x.Id == "4"), $"Expected to contain next result after docId {luceneResults2.SearchAfter.DocumentId}");
+                Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults2.Any(y => y.Id == x.Id)), "Results should not overlap");
+                Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults.Any(y => y.Id == x.Id)), "Results should not overlap");
+
+                Assert.AreNotEqual(results.First().Id, results2.First().Id, "Results should be different");
+            }
+        }
+
+        [Test]
+        public void SearchAfter_NonSorted_Results_Returns_Different_Results()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(luceneDir, analyzer))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "world", writerName = "administrator" }),
+                    ValueSet.FromObject(2.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "umbraco", writerName = "administrator" }),
+                    ValueSet.FromObject(3.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "umbraco", writerName = "administrator" }),
+                    ValueSet.FromObject(4.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "nz", writerName = "administrator" }),
+                    ValueSet.FromObject(5.ToString(), "content",
+                        new { nodeName = "hello", headerText = "world", writerName = "blah" })
+                    });
+
+                var searcher = indexer.Searcher;
+
+                //Arrange
+                var sc = searcher.CreateQuery("content")
+                    .Field("writerName", "administrator");
                 var luceneOptions = new LuceneQueryOptions(0, 2);
                 //Act
 

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -2587,8 +2587,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 //There are 4 results
                 // First query skips 0 and takes 2.
-                var results = sc.Execute(luceneOptions);
-                var luceneResults = results as ILuceneSearchResults;
+                var luceneResults = sc.ExecuteWithLucene(luceneOptions);
                 Assert.IsNotNull(luceneResults);
                 Assert.IsNotNull(luceneResults.SearchAfter, "Search After details should be available");
                 var luceneResults1List = luceneResults.ToList();
@@ -2601,8 +2600,7 @@ namespace Examine.Test.Examine.Lucene.Search
                     luceneResults.SearchAfter.Fields,
                     luceneResults.SearchAfter.ShardIndex.Value);
                 var luceneOptions2 = new LuceneQueryOptions(0, 1, searchAfter);
-                var results2 = sc.Execute(luceneOptions2);
-                var luceneResults2 = results2 as ILuceneSearchResults;
+                var luceneResults2 = sc.ExecuteWithLucene(luceneOptions2);
                 var luceneResults2List = luceneResults2.ToList();
                 Assert.IsTrue(luceneResults2List.Any(x => x.Id == "3"), $"Expected to contain next result after docId {luceneResults.SearchAfter.DocumentId}");
                 Assert.IsNotNull(luceneResults2);
@@ -2612,15 +2610,14 @@ namespace Examine.Test.Examine.Lucene.Search
                 // Third query result continues after result 2 (zero indexed), Takes 1
                 var searchAfter2 = new SearchAfterOptions(luceneResults2.SearchAfter.DocumentId, luceneResults2.SearchAfter.DocumentScore, luceneResults2.SearchAfter.Fields, luceneResults2.SearchAfter.ShardIndex.Value);
                 var luceneOptions3 = new LuceneQueryOptions(0, 1, searchAfter2);
-                var results3 = sc.Execute(luceneOptions3);
-                var luceneResults3 = results3 as ILuceneSearchResults;
+                var luceneResults3 = sc.ExecuteWithLucene(luceneOptions3);
                 Assert.IsNotNull(luceneResults3);
                 var luceneResults3List = luceneResults3.ToList();
                 Assert.IsTrue(luceneResults3List.Any(x => x.Id == "4"), $"Expected to contain next result after docId {luceneResults2.SearchAfter.DocumentId}");
                 Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults2.Any(y => y.Id == x.Id)), "Results should not overlap");
                 Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults.Any(y => y.Id == x.Id)), "Results should not overlap");
 
-                Assert.AreNotEqual(results.First().Id, results2.First().Id, "Results should be different");
+                Assert.AreNotEqual(luceneResults.First().Id, luceneResults2.First().Id, "Results should be different");
             }
         }
 
@@ -2654,8 +2651,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 //There are 4 results
                 // First query skips 0 and takes 2.
-                var results = sc.Execute(luceneOptions);
-                var luceneResults = results as ILuceneSearchResults;
+                var luceneResults = sc.ExecuteWithLucene(luceneOptions);
                 Assert.IsNotNull(luceneResults);
                 Assert.IsNotNull(luceneResults.SearchAfter, "Search After details should be available");
                 var luceneResults1List = luceneResults.ToList();
@@ -2668,8 +2664,7 @@ namespace Examine.Test.Examine.Lucene.Search
                     luceneResults.SearchAfter.Fields,
                     luceneResults.SearchAfter.ShardIndex.Value);
                 var luceneOptions2 = new LuceneQueryOptions(0, 1, searchAfter);
-                var results2 = sc.Execute(luceneOptions2);
-                var luceneResults2 = results2 as ILuceneSearchResults;
+                var luceneResults2 = sc.ExecuteWithLucene(luceneOptions2);
                 var luceneResults2List = luceneResults2.ToList();
                 Assert.IsTrue(luceneResults2List.Any(x => x.Id == "3"), $"Expected to contain next result after docId {luceneResults.SearchAfter.DocumentId}");
                 Assert.IsNotNull(luceneResults2);
@@ -2679,15 +2674,14 @@ namespace Examine.Test.Examine.Lucene.Search
                 // Third query result continues after result 2 (zero indexed), Takes 1
                 var searchAfter2 = new SearchAfterOptions(luceneResults2.SearchAfter.DocumentId, luceneResults2.SearchAfter.DocumentScore, luceneResults2.SearchAfter.Fields, luceneResults2.SearchAfter.ShardIndex.Value);
                 var luceneOptions3 = new LuceneQueryOptions(0, 1, searchAfter2);
-                var results3 = sc.Execute(luceneOptions3);
-                var luceneResults3 = results3 as ILuceneSearchResults;
+                var luceneResults3 = sc.ExecuteWithLucene(luceneOptions3);
                 Assert.IsNotNull(luceneResults3);
                 var luceneResults3List = luceneResults3.ToList();
                 Assert.IsTrue(luceneResults3List.Any(x => x.Id == "4"), $"Expected to contain next result after docId {luceneResults2.SearchAfter.DocumentId}");
                 Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults2.Any(y => y.Id == x.Id)), "Results should not overlap");
                 Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults.Any(y => y.Id == x.Id)), "Results should not overlap");
 
-                Assert.AreNotEqual(results.First().Id, results2.First().Id, "Results should be different");
+                Assert.AreNotEqual(luceneResults.First().Id, luceneResults2.First().Id, "Results should be different");
             }
         }
 

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -2556,6 +2556,71 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
+        [Test]
+        public void SearchAfter_Results_Returns_Different_Results()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(luceneDir, analyzer))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "world", writerName = "administrator" }),
+                    ValueSet.FromObject(2.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "umbraco", writerName = "administrator" }),
+                    ValueSet.FromObject(3.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "umbraco", writerName = "administrator" }),
+                    ValueSet.FromObject(4.ToString(), "content",
+                        new { nodeName = "umbraco", headerText = "nz", writerName = "administrator" }),
+                    ValueSet.FromObject(5.ToString(), "content",
+                        new { nodeName = "hello", headerText = "world", writerName = "blah" })
+                    });
+
+                var searcher = indexer.Searcher;
+
+                //Arrange
+                var sc = searcher.CreateQuery("content")
+                    .Field("writerName", "administrator")
+                    .OrderByDescending(new SortableField("id",SortType.Int));
+                var luceneOptions = new LuceneQueryOptions(0, 2);
+                //Act
+
+                //There are 4 results
+                // First query skips 0 and takes 2.
+                var results = sc.Execute(luceneOptions);
+                var luceneResults = results as ILuceneSearchResults;
+                Assert.IsNotNull(luceneResults);
+                Assert.IsNotNull(luceneResults.SearchAfter,"Search After details should be available");
+                var luceneResults1List = luceneResults.ToList();
+                Assert.IsTrue(luceneResults1List.Any(x => x.Id == "1"));
+                Assert.IsTrue(luceneResults1List.Any(x => x.Id == "2"));
+
+                // Second query result continues after result 1 (zero indexed), Takes 1, should not include any of the results before or include the SearchAfter docid / scoreid
+                var searchAfter = new SearchAfterOptions(luceneResults.SearchAfter.DocumentId, luceneResults.SearchAfter.DocumentScore, luceneResults.SearchAfter.Fields, luceneResults.SearchAfter.ShardIndex.Value);
+                var luceneOptions2 = new LuceneQueryOptions(1,1, searchAfter);
+                var results2 = sc.Execute(luceneOptions2);
+                var luceneResults2 = results2 as ILuceneSearchResults;
+                var luceneResults2List = luceneResults2.ToList();
+                Assert.IsTrue(luceneResults2List.Any(x => x.Id == "3"), $"Expected to contain next result after docId {luceneResults.SearchAfter.DocumentId}");
+                Assert.IsNotNull(luceneResults2);
+
+                Assert.IsFalse(luceneResults2List.Any(x => luceneResults.ToList().Any(y => y.Id == x.Id)), "Results should not overlap");
+
+                // Third query result continues after result 2 (zero indexed), Takes 1
+                var searchAfter2 = new SearchAfterOptions(luceneResults2.SearchAfter.DocumentId, luceneResults2.SearchAfter.DocumentScore, luceneResults2.SearchAfter.Fields, luceneResults2.SearchAfter.ShardIndex.Value);
+                var luceneOptions3 = new LuceneQueryOptions(2, 1, searchAfter2);
+                var results3 = sc.Execute(luceneOptions3);
+                var luceneResults3 = results3 as ILuceneSearchResults;
+                Assert.IsNotNull(luceneResults3);
+                var luceneResults3List = luceneResults3.ToList();
+                Assert.IsTrue(luceneResults3List.Any(x => x.Id == "4"), $"Expected to contain next result after docId {luceneResults2.SearchAfter.DocumentId}");
+                Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults2.Any(y => y.Id == x.Id)), "Results should not overlap");
+                Assert.IsFalse(luceneResults3.ToList().Any(x => luceneResults.Any(y => y.Id == x.Id)), "Results should not overlap");
+
+                Assert.AreNotEqual(results.First().Id, results2.First().Id, "Results should be different");
+            }
+        }
+
 #if NET6_0_OR_GREATER
         [Test]
         public void Range_DateOnly()


### PR DESCRIPTION
Support for efficient deep paging in lucene.net. 
Uses SearchAfter instead of Search when the SearchAfterOptions are available.
This allows lucene to efficiently skip documents before the last document from the previous page fetched for a search.

Steps:
1. Build and execute your query as normal.
2. Cast the ISearchResults from IQueryExecutor.Execute to ILuceneSearchResults
3. Store ILuceneSearchResults.SearchAfter (SearchAfterOptions) for the next page. It may be worth serializing this class and cryptographically hashing it to prevent tampering in a web application so that it can be made available to the next request for the next page.
4. Create the same query as the previous request.
5. When calling IQueryExecutor.Execute. Pass in new LuceneQueryOptions(skip,take, SearchAfterOptions); Skip will be ignored, the next take documents will be retrieved after the SearchAfterOptions document.
6. Repeat Steps 2-5 for each page.

Added documentation.
Added tests.