### PR TITLE
Similarity support

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -250,3 +250,60 @@ var query = (LuceneSearchQuery)query.NativeQuery("hello:world").And(); // Make q
 query.LuceneQuery(NumericRangeQuery.NewInt64Range("numTest", 4, 5, true, true)); // Add the raw lucene query
 var results = query.Execute();
 ```
+
+
+### Use a Lucene Similarity
+Simliarity defines the components of Lucene scoring.
+
+See LuceneSearchOptionsSimilarities for Similarities that are available by default.
+
+- LuceneSearchOptionsSimilarities.ExamineDefault is the default Similarity used by Examine
+- LuceneSearchOptionsSimilarities.Classic is the default Similarity used by Lucene.NET 4
+- LuceneSearchOptionsSimilarities.BM25 is the default in later versions of Lucene.
+- LuceneSearchOptionsSimilarities.LMDirichlet
+- LuceneSearchOptionsSimilarities.LMJelinekMercerTitle
+- LuceneSearchOptionsSimilarities.LMJelinekMercerLongText
+
+#### Examine Default Similarity
+
+```csharp
+var searcher = (BaseLuceneSearcher)indexer.Searcher;
+var query = searcher.CreateQuery(searchOptions: new LuceneSearchOptions
+                    {
+                        // Set Similarity
+                        Similarity = LuceneSearchOptionsSimilarities.ExamineDefault
+                    });
+  // Look for any addresses with the exact phrase "Hills Rockyroad Hollywood"
+ .Field("Address", "Hills Rockyroad Hollywood".Escape())
+ .Execute();
+
+```
+
+#### Classic/Default Similarity
+
+```csharp
+var searcher = (BaseLuceneSearcher)indexer.Searcher;
+var query = searcher.CreateQuery(searchOptions: new LuceneSearchOptions
+                    {
+                        // Set Similarity
+                        Similarity = LuceneSearchOptionsSimilarities.Classic
+                    });
+  // Look for any addresses with the exact phrase "Hills Rockyroad Hollywood"
+ .Field("Address", "Hills Rockyroad Hollywood".Escape())
+ .Execute();
+
+```
+
+#### BM25 Similarity
+
+```csharp
+var searcher = (BaseLuceneSearcher)indexer.Searcher;
+var query = searcher.CreateQuery(searchOptions: new LuceneSearchOptions
+                    {
+                        Similarity = LuceneSearchOptionsSimilarities.BM25
+                    });
+  // Look for any addresses with the exact phrase "Hills Rockyroad Hollywood"
+ .Field("Address", "Hills Rockyroad Hollywood".Escape())
+ .Execute();
+
+```

--- a/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
@@ -40,6 +40,16 @@ namespace Examine.Lucene.Providers
         /// </summary>
         /// <param name="category">The type of data in the index.</param>
         /// <param name="defaultOperation">The default operation.</param>
+        /// <param name="searchOptions">Lucene Search Options</param>
+        /// <returns></returns>
+        public IQuery CreateQuery(string category = null, BooleanOperation defaultOperation = BooleanOperation.And, LuceneSearchOptions searchOptions = null)
+            => CreateQuery(category, defaultOperation, LuceneAnalyzer, searchOptions ?? new LuceneSearchOptions());
+
+        /// <summary>
+        /// Creates an instance of SearchCriteria for the provider
+        /// </summary>
+        /// <param name="category">The type of data in the index.</param>
+        /// <param name="defaultOperation">The default operation.</param>
         /// <param name="luceneAnalyzer"></param>
         /// <param name="searchOptions"></param>
         /// <returns></returns>

--- a/src/Examine.Lucene/Search/DictionaryPerFieldSimilarityWrapper.cs
+++ b/src/Examine.Lucene/Search/DictionaryPerFieldSimilarityWrapper.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Lucene.Net.Search.Similarities;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Use a similarity per field, falling back to a default similarity.
+    /// </summary>
+    public class DictionaryPerFieldSimilarityWrapper : PerFieldSimilarityWrapper
+    {
+        private readonly Similarity _defaultSimilarity;
+        private readonly IReadOnlyDictionary<string, Similarity> _fieldSimilarities;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DictionaryPerFieldSimilarityWrapper"/>.
+        /// </summary>
+        /// <param name="fieldSimilarities">Mapping from field name to Similarity</param>
+        /// <param name="defaultSimilarity">Default Similarity to use for non mapped fields</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public DictionaryPerFieldSimilarityWrapper(IReadOnlyDictionary<string, Similarity> fieldSimilarities, Similarity defaultSimilarity)
+        {
+            _defaultSimilarity = defaultSimilarity ?? throw new ArgumentNullException(nameof(defaultSimilarity));
+            _fieldSimilarities = fieldSimilarities ?? throw new ArgumentNullException(nameof(fieldSimilarities));
+        }
+
+        /// <inheritdoc/>
+        public override Similarity Get(string field)
+        {
+            if (_fieldSimilarities.TryGetValue(field, out var similarity))
+            {
+                return similarity;
+            }
+            return _defaultSimilarity;
+        }
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -100,6 +100,10 @@ namespace Examine.Lucene.Search
                 {
                     searcher.IndexSearcher.Similarity = _luceneSearchOptions.Similarity;
                 }
+                else
+                {
+                    searcher.IndexSearcher.Similarity = LuceneSearchOptionsSimilarities.ExamineDefault;
+                }
 
                 searcher.IndexSearcher.Search(_luceneQuery, topDocsCollector);
 

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -5,6 +5,7 @@ using Examine.Search;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
+using Lucene.Net.Search.Similarities;
 
 namespace Examine.Lucene.Search
 {
@@ -19,13 +20,15 @@ namespace Examine.Lucene.Search
         private readonly ISearchContext _searchContext;
         private readonly Query _luceneQuery;
         private readonly ISet<string> _fieldsToLoad;
+        private readonly LuceneSearchOptions _luceneSearchOptions;
         private int? _maxDoc;
 
-        internal LuceneSearchExecutor(QueryOptions options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext, ISet<string> fieldsToLoad)
+        internal LuceneSearchExecutor(QueryOptions options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext, ISet<string> fieldsToLoad, LuceneSearchOptions luceneSearchOptions)
         {
             _options = options ?? QueryOptions.Default;
             _luceneQuery = query ?? throw new ArgumentNullException(nameof(query));
             _fieldsToLoad = fieldsToLoad;
+            _luceneSearchOptions = luceneSearchOptions;
             _sortField = sortField ?? throw new ArgumentNullException(nameof(sortField));
             _searchContext = searchContext ?? throw new ArgumentNullException(nameof(searchContext));
         }
@@ -93,6 +96,11 @@ namespace Examine.Lucene.Search
 
             using (ISearcherReference searcher = _searchContext.GetSearcher())
             {
+                if (_luceneSearchOptions != null && _luceneSearchOptions.Similarity != null)
+                {
+                    searcher.IndexSearcher.Similarity = _luceneSearchOptions.Similarity;
+                }
+
                 searcher.IndexSearcher.Search(_luceneQuery, topDocsCollector);
 
                 TopDocs topDocs;

--- a/src/Examine.Lucene/Search/LuceneSearchOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using Lucene.Net.Documents;
 using Lucene.Net.Search;
+using Lucene.Net.Search.Similarities;
 
 namespace Examine.Lucene.Search
 {
@@ -76,5 +77,10 @@ namespace Examine.Lucene.Search
         //     Sets the default Lucene.Net.Documents.DateTools.Resolution used for certain field
         //     when no Lucene.Net.Documents.DateTools.Resolution is defined for this field.
         public DateResolution? DateResolution { get; set; }
+
+        /// <summary>
+        /// Search Similarity.
+        /// </summary>
+        public Similarity Similarity { get; set; }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchOptionsSimilarities.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchOptionsSimilarities.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Lucene.Net.Search.Similarities;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Common Similarities for Lucene.NET Search
+    /// </summary>
+    public static class LuceneSearchOptionsSimilarities
+    {
+        /// <summary>
+        /// Default Similarity for Examine Lucene.
+        /// </summary>
+        /// <remarks>In Examine V3, this is <see cref="DefaultSimilarity"/>. In Examine V4 this will change to <see cref="BM25Similarity"/></remarks>
+        public static readonly Similarity ExamineDefault = new DefaultSimilarity();
+
+        /// <summary>
+        /// Classic Similarity for Lucene. <see cref="DefaultSimilarity"/>
+        /// </summary>
+        public static readonly Similarity Classic = new DefaultSimilarity();
+
+        /// <summary>
+        /// BM25Similarity with default parameters for Lucene. <see cref="BM25Similarity"/>
+        /// </summary>
+        public static readonly Similarity BM25 = new BM25Similarity();
+
+        /// <summary>
+        /// LMDirichletSimilarity with default parameters for Lucene. <see cref="LMDirichletSimilarity"/>
+        /// </summary>
+        public static readonly Similarity LMDirichlet = new LMDirichletSimilarity();
+
+        /// <summary>
+        /// LMJelinekMercerSimilarity with parameter 0.1f which is suitable for title searches. <see cref="LMJelinekMercerSimilarity"/>
+        /// </summary>
+        public static readonly Similarity LMJelinekMercerTitle = new LMJelinekMercerSimilarity(0.1f);
+
+        /// <summary>
+        /// LMJelinekMercerSimilarity with parameter 0.7f which is suitable for long text searches. <see cref="LMJelinekMercerSimilarity"/>
+        /// </summary>
+        public static readonly Similarity LMJelinekMercerLongText = new LMJelinekMercerSimilarity(0.7f);
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -227,7 +227,7 @@ namespace Examine.Lucene.Search
                 }
             }
 
-            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad);
+            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, SearchOptions);
 
             var pagesResults = executor.Execute();
 

--- a/src/Examine.Test/Examine.Lucene/Search/SimilarityTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/SimilarityTests.cs
@@ -39,7 +39,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
                     searchOptions: new LuceneSearchOptions
                     {
-                        Similarity = new DefaultSimilarity()
+                        Similarity = LuceneSearchOptionsSimilarities.ExamineDefault
                     }).All();
 
                 Console.WriteLine(query);
@@ -74,7 +74,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
                     searchOptions: new LuceneSearchOptions
                     {
-                        Similarity = new BM25Similarity()
+                        Similarity = LuceneSearchOptionsSimilarities.BM25
                     }).All();
 
                 Console.WriteLine(query);
@@ -110,7 +110,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
                     searchOptions: new LuceneSearchOptions
                     {
-                        Similarity = new LMDirichletSimilarity()
+                        Similarity = LuceneSearchOptionsSimilarities.LMDirichlet
                     }).All();
 
                 Console.WriteLine(query);
@@ -145,7 +145,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
                     searchOptions: new LuceneSearchOptions
                     {
-                        Similarity = new LMJelinekMercerSimilarity(0.1f)
+                        Similarity = LuceneSearchOptionsSimilarities.LMJelinekMercerTitle
                     }).All();
 
                 Console.WriteLine(query);
@@ -180,7 +180,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
                     searchOptions: new LuceneSearchOptions
                     {
-                        Similarity = new LMJelinekMercerSimilarity(0.7f)
+                        Similarity = LuceneSearchOptionsSimilarities.LMJelinekMercerLongText
                     }).All();
 
                 Console.WriteLine(query);

--- a/src/Examine.Test/Examine.Lucene/Search/SimilarityTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/SimilarityTests.cs
@@ -36,7 +36,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var searcher = (BaseLuceneSearcher)indexer.Searcher;
 
-                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                var query = searcher.CreateQuery("cOntent",
                     searchOptions: new LuceneSearchOptions
                     {
                         Similarity = LuceneSearchOptionsSimilarities.ExamineDefault
@@ -71,7 +71,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var searcher = (BaseLuceneSearcher)indexer.Searcher;
 
-                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                var query = searcher.CreateQuery("cOntent",
                     searchOptions: new LuceneSearchOptions
                     {
                         Similarity = LuceneSearchOptionsSimilarities.BM25
@@ -107,7 +107,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var searcher = (BaseLuceneSearcher)indexer.Searcher;
 
-                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                var query = searcher.CreateQuery("cOntent",
                     searchOptions: new LuceneSearchOptions
                     {
                         Similarity = LuceneSearchOptionsSimilarities.LMDirichlet
@@ -142,7 +142,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var searcher = (BaseLuceneSearcher)indexer.Searcher;
 
-                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                var query = searcher.CreateQuery("cOntent",
                     searchOptions: new LuceneSearchOptions
                     {
                         Similarity = LuceneSearchOptionsSimilarities.LMJelinekMercerTitle
@@ -177,7 +177,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var searcher = (BaseLuceneSearcher)indexer.Searcher;
 
-                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                var query = searcher.CreateQuery("cOntent",
                     searchOptions: new LuceneSearchOptions
                     {
                         Similarity = LuceneSearchOptionsSimilarities.LMJelinekMercerLongText

--- a/src/Examine.Test/Examine.Lucene/Search/SimilarityTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/SimilarityTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Examine.Lucene.Providers;
+using Examine.Lucene.Search;
+using Examine.Search;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Search.Similarities;
+using NUnit.Framework;
+
+namespace Examine.Test.Examine.Lucene.Search
+{
+    [TestFixture]
+    public class SimilarityTests : ExamineBaseTest
+    {
+        [Test]
+        public void Default_Similarity()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("parentID", FieldDefinitionTypes.Integer))))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "cOntent",
+                        new { nodeName = "location 1", bodyText = "Zanzibar is in Africa"}),
+                    ValueSet.FromObject(2.ToString(), "cOntent",
+                        new { nodeName = "location 2", bodyText = "In Canada there is a town called Sydney in Nova Scotia"}),
+                    ValueSet.FromObject(3.ToString(), "cOntent",
+                        new { nodeName = "location 3", bodyText = "Sydney is the capital of NSW in Australia"})
+                    });
+
+                var searcher = (BaseLuceneSearcher)indexer.Searcher;
+
+                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                    searchOptions: new LuceneSearchOptions
+                    {
+                        Similarity = new DefaultSimilarity()
+                    }).All();
+
+                Console.WriteLine(query);
+
+                var results = query.Execute();
+
+                Assert.AreEqual(3, results.TotalItemCount);
+            }
+        }
+
+        [Test]
+        public void BM25_Similarity()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("parentID", FieldDefinitionTypes.Integer))))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "cOntent",
+                        new { nodeName = "location 1", bodyText = "Zanzibar is in Africa"}),
+                    ValueSet.FromObject(2.ToString(), "cOntent",
+                        new { nodeName = "location 2", bodyText = "In Canada there is a town called Sydney in Nova Scotia"}),
+                    ValueSet.FromObject(3.ToString(), "cOntent",
+                        new { nodeName = "location 3", bodyText = "Sydney is the capital of NSW in Australia"})
+                    });
+
+                var searcher = (BaseLuceneSearcher)indexer.Searcher;
+
+                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                    searchOptions: new LuceneSearchOptions
+                    {
+                        Similarity = new BM25Similarity()
+                    }).All();
+
+                Console.WriteLine(query);
+
+                var results = query.Execute();
+
+                Assert.AreEqual(3, results.TotalItemCount);
+            }
+        }
+
+
+        [Test]
+        public void LMDirichlet_Similarity()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("parentID", FieldDefinitionTypes.Integer))))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "cOntent",
+                        new { nodeName = "location 1", bodyText = "Zanzibar is in Africa"}),
+                    ValueSet.FromObject(2.ToString(), "cOntent",
+                        new { nodeName = "location 2", bodyText = "In Canada there is a town called Sydney in Nova Scotia"}),
+                    ValueSet.FromObject(3.ToString(), "cOntent",
+                        new { nodeName = "location 3", bodyText = "Sydney is the capital of NSW in Australia"})
+                    });
+
+                var searcher = (BaseLuceneSearcher)indexer.Searcher;
+
+                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                    searchOptions: new LuceneSearchOptions
+                    {
+                        Similarity = new LMDirichletSimilarity()
+                    }).All();
+
+                Console.WriteLine(query);
+
+                var results = query.Execute();
+
+                Assert.AreEqual(3, results.TotalItemCount);
+            }
+        }
+
+        [Test]
+        public void LMJelinekMercer_Title_Similarity()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("parentID", FieldDefinitionTypes.Integer))))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "cOntent",
+                        new { nodeName = "location 1", bodyText = "Zanzibar is in Africa"}),
+                    ValueSet.FromObject(2.ToString(), "cOntent",
+                        new { nodeName = "location 2", bodyText = "In Canada there is a town called Sydney in Nova Scotia"}),
+                    ValueSet.FromObject(3.ToString(), "cOntent",
+                        new { nodeName = "location 3", bodyText = "Sydney is the capital of NSW in Australia"})
+                    });
+
+                var searcher = (BaseLuceneSearcher)indexer.Searcher;
+
+                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                    searchOptions: new LuceneSearchOptions
+                    {
+                        Similarity = new LMJelinekMercerSimilarity(0.1f)
+                    }).All();
+
+                Console.WriteLine(query);
+
+                var results = query.Execute();
+
+                Assert.AreEqual(3, results.TotalItemCount);
+            }
+        }
+
+        [Test]
+        public void LMJelinekMercer_LongText_Similarity()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("parentID", FieldDefinitionTypes.Integer))))
+            {
+                indexer.IndexItems(new[] {
+                    ValueSet.FromObject(1.ToString(), "cOntent",
+                        new { nodeName = "location 1", bodyText = "Zanzibar is in Africa"}),
+                    ValueSet.FromObject(2.ToString(), "cOntent",
+                        new { nodeName = "location 2", bodyText = "In Canada there is a town called Sydney in Nova Scotia"}),
+                    ValueSet.FromObject(3.ToString(), "cOntent",
+                        new { nodeName = "location 3", bodyText = "Sydney is the capital of NSW in Australia"})
+                    });
+
+                var searcher = (BaseLuceneSearcher)indexer.Searcher;
+
+                var query = searcher.CreateQuery("cOntent", BooleanOperation.And, searcher.LuceneAnalyzer,
+                    searchOptions: new LuceneSearchOptions
+                    {
+                        Similarity = new LMJelinekMercerSimilarity(0.7f)
+                    }).All();
+
+                Console.WriteLine(query);
+
+                var results = query.Execute();
+
+                Assert.AreEqual(3, results.TotalItemCount);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
What?

This pull request adds support for setting the Similarity used for querying a Lucene Index. 

Why?
This can improve the scoring of the documents in the index for more relevant results.

Example:

```
var searcher = (BaseLuceneSearcher)indexer.Searcher;
var query = searcher.CreateQuery("cOntent",
                    searchOptions: new LuceneSearchOptions
                    {
                        Similarity = LuceneSearchOptionsSimilarities.BM25
                    }).All();
 var results = query.Execute();
```

How?

- Added LuceneSearchOptions.Similarity property to set the Similarity on a query.
- Added LuceneSearchOptionsSimilarities with a set of preconfigured defaults.
- Set LuceneSearchOptionsSimilarities.ExamineDefault to the existing default similarity (Lucene.Net.Similarities.DefaultSimilarity)
- Added recommendation to change LuceneSearchOptionsSimilarities.ExamineDefault to BM25Similarity in Examine V4
- Added documentation
- Added tests

