### PR TITLE
feat: added custom score queries

### DIFF
--- a/src/Examine.Lucene/LuceneIndexOptions.cs
+++ b/src/Examine.Lucene/LuceneIndexOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Examine.Lucene.Scoring;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Index;
@@ -20,5 +21,7 @@ namespace Examine.Lucene
         /// This is generally used to initialize any custom value types for your indexer since the value type collection cannot be modified at runtime.
         /// </summary>
         public IReadOnlyDictionary<string, IFieldValueTypeFactory> IndexValueTypesFactory { get; set; }
+
+        public IList<IScoringProfile> ScoreProfiles { get; set; }
     }
 }

--- a/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/BaseLuceneSearcher.cs
@@ -3,6 +3,8 @@ using Lucene.Net.Analysis;
 using Lucene.Net.Search;
 using Examine.Lucene.Search;
 using Examine.Search;
+using System.Collections.Generic;
+using Examine.Lucene.Scoring;
 
 namespace Examine.Lucene.Providers
 {
@@ -11,17 +13,21 @@ namespace Examine.Lucene.Providers
     ///</summary>
     public abstract class BaseLuceneSearcher : BaseSearchProvider
     {
+        public IList<IScoringProfile> ScoringProfiles { get; }
+
         /// <summary>
         /// Constructor to allow for creating an indexer at runtime
         /// </summary>
         /// <param name="name"></param>
         /// <param name="analyzer"></param>
-        protected BaseLuceneSearcher(string name, Analyzer analyzer)
+        protected BaseLuceneSearcher(string name, Analyzer analyzer, IList<IScoringProfile> scoringProfiles = null)
             : base(name)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
             LuceneAnalyzer = analyzer;
+
+            ScoringProfiles = scoringProfiles ?? new List<IScoringProfile>();
         }
 
         /// <summary>
@@ -48,7 +54,7 @@ namespace Examine.Lucene.Providers
             if (luceneAnalyzer == null)
                 throw new ArgumentNullException(nameof(luceneAnalyzer));
 
-            return new LuceneSearchQuery(GetSearchContext(), category, luceneAnalyzer, searchOptions, defaultOperation);
+            return new LuceneSearchQuery(GetSearchContext(), category, luceneAnalyzer, searchOptions, defaultOperation, ScoringProfiles);
         }
 
         /// <inheritdoc />

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -1048,7 +1048,7 @@ namespace Examine.Lucene.Providers
             // wait for most recent changes when first creating the searcher
             WaitForChanges();
 
-            return new LuceneSearcher(name + "Searcher", searcherManager, FieldAnalyzer, FieldValueTypeCollection);
+            return new LuceneSearcher(name + "Searcher", searcherManager, FieldAnalyzer, FieldValueTypeCollection, _options.ScoreProfiles);
         }
 
         /// <summary>

--- a/src/Examine.Lucene/Providers/LuceneSearcher.cs
+++ b/src/Examine.Lucene/Providers/LuceneSearcher.cs
@@ -2,7 +2,8 @@ using System;
 using Examine.Lucene.Search;
 using Lucene.Net.Search;
 using Lucene.Net.Analysis;
-
+using System.Collections.Generic;
+using Examine.Lucene.Scoring;
 
 namespace Examine.Lucene.Providers
 {
@@ -23,8 +24,8 @@ namespace Examine.Lucene.Providers
         /// <param name="writer"></param>
         /// <param name="analyzer"></param>
         /// <param name="fieldValueTypeCollection"></param>
-        public LuceneSearcher(string name, SearcherManager searcherManager, Analyzer analyzer, FieldValueTypeCollection fieldValueTypeCollection)
-            : base(name, analyzer)
+        public LuceneSearcher(string name, SearcherManager searcherManager, Analyzer analyzer, FieldValueTypeCollection fieldValueTypeCollection, IList<IScoringProfile> scoringProfiles = null)
+            : base(name, analyzer, scoringProfiles)
         {
             _searcherManager = searcherManager;
             _fieldValueTypeCollection = fieldValueTypeCollection;

--- a/src/Examine.Lucene/Scoring/IScoringProfile.cs
+++ b/src/Examine.Lucene/Scoring/IScoringProfile.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Lucene.Net.Search;
+
+namespace Examine.Lucene.Scoring
+{
+    public interface IScoringProfile
+    {
+        Query GetScoreQuery(Query inner);
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneSearchExtensions.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExtensions.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Runtime.CompilerServices;
+using Examine.Lucene.Providers;
+using Examine.Lucene.Scoring;
 using Examine.Search;
 using Lucene.Net.Search;
 
@@ -65,6 +68,18 @@ namespace Examine.Lucene.Search
                 }
             }
             throw new NotSupportedException("QueryExecutor is not Lucene.NET");
+        }
+
+        public static void AddScoringProfile(this ISearcher searcher, IScoringProfile scoringProfile)
+        {
+            if(searcher is LuceneSearcher luceneSearcher)
+            {
+                luceneSearcher.ScoringProfiles.Add(scoringProfile);
+
+                return;
+            }
+
+            throw new NotSupportedException("Searcher is not Lucene.NET");
         }
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/Scoing/FreshnessScoringProfile.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/Scoing/FreshnessScoringProfile.cs
@@ -1,0 +1,94 @@
+using System;
+using Examine.Lucene.Scoring;
+using Lucene.Net.Documents;
+using Lucene.Net.Index;
+using Lucene.Net.Queries;
+using Lucene.Net.Search;
+
+namespace Examine.Test.Examine.Lucene.Search.Scoring
+{
+    public class FreshnessScoringProfile : IScoringProfile
+    {
+        private readonly string _fieldName;
+        private readonly TimeSpan _duration;
+        private readonly float _boost;
+
+        public FreshnessScoringProfile(string fieldName, TimeSpan duration, float boost)
+        {
+            _fieldName = fieldName;
+            _duration = duration;
+            _boost = boost;
+        }
+
+        public Query GetScoreQuery(Query inner) => new FreshnessScoreQuery(inner, _fieldName, _duration, _boost);
+    }
+
+    public class FreshnessScoreQuery : CustomScoreQuery
+    {
+        private readonly string _fieldName;
+        private readonly TimeSpan _duration;
+        private readonly float _boost;
+
+        public FreshnessScoreQuery(Query subQuery, string fieldName, TimeSpan duration, float boost) : base(subQuery)
+        {
+            _fieldName = fieldName;
+            _duration = duration;
+            _boost = boost;
+        }
+
+        protected override CustomScoreProvider GetCustomScoreProvider(AtomicReaderContext context) => new FreshnessScoreProvider(context, _fieldName, _duration, _boost);
+
+        private class FreshnessScoreProvider : CustomScoreProvider
+        {
+            private readonly string _fieldName;
+            private readonly TimeSpan _duration;
+            private readonly float _boost;
+
+            public FreshnessScoreProvider(AtomicReaderContext context, string fieldName, TimeSpan duration, float boost) : base(context)
+            {
+                _fieldName = fieldName;
+                _duration = duration;
+                _boost = boost;
+            }
+
+            public override float CustomScore(int doc, float subQueryScore, float valSrcScore)
+            {
+                var date = GetDocumentDate(doc);
+
+                var score = subQueryScore;
+
+                if (date != null)
+                {
+                    var end = DateTime.Now;
+                    var start = end.Subtract(_duration);
+
+                    if (date > start && date < end || date < start && date > end)
+                    {
+                        score *= _boost;
+                    }
+                }
+
+                return score;
+            }
+
+            private DateTime? GetDocumentDate(int doc)
+            {
+                var document = m_context.Reader.Document(doc);
+
+                var field = document.GetField(_fieldName);
+
+                if (field != null && field.NumericType == NumericFieldType.INT64)
+                {
+                    var timestamp = field.GetInt64Value() ?? 0;
+
+                    var date = new DateTime(timestamp);
+
+                    return date;
+                }
+
+                return null;
+            }
+
+        }
+    }
+}

--- a/src/Examine.Test/Examine.Lucene/Search/ScoringProfileTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/ScoringProfileTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Examine.Lucene.Scoring;
+using Examine.Lucene.Search;
+using Examine.Test.Examine.Lucene.Search.Scoring;
+using Lucene.Net.Analysis.Standard;
+using NUnit.Framework;
+
+namespace Examine.Test.Examine.Lucene.Search
+{
+    [TestFixture]
+    public class ScoringProfileTests : ExamineBaseTest
+    {
+        [Test]
+        public void Score_No_Profiles()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime"))))
+            {
+                indexer.IndexItems(new[]
+                {
+                    ValueSet.FromObject(123.ToString(), "content",
+                        new
+                        {
+                            created = new DateTime(2000, 01, 02),
+                            bodyText = "lorem ipsum",
+                            nodeTypeAlias = "CWS_Home"
+                        })
+                });
+
+
+                var searcher = indexer.Searcher;
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.191783011f, numberSortedResult.First().Score);
+            }
+        }
+
+        [Test]
+        public void Score_Freshness_Profile_Out_Of_Range()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime")),
+                scoringProfiles: new List<IScoringProfile> { new FreshnessScoringProfile("created", new TimeSpan(1, 0, 0, 0), 1.5f) }))
+            {
+                indexer.IndexItems(new[]
+                {
+                    ValueSet.FromObject(123.ToString(), "content",
+                        new
+                        {
+                            created = DateTime.Now.AddDays(-2),
+                            bodyText = "lorem ipsum",
+                            nodeTypeAlias = "CWS_Home"
+                        })
+                });
+
+
+                var searcher = indexer.Searcher;
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.191783011f, numberSortedResult.First().Score);
+            }
+        }
+
+        [Test]
+        public void Score_Freshness_Profile_In_Range()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime")),
+                scoringProfiles: new List<IScoringProfile> { new FreshnessScoringProfile("created", new TimeSpan(1, 0, 0, 0), 1.5f) }))
+            {
+                indexer.IndexItems(new[]
+                {
+                    ValueSet.FromObject(123.ToString(), "content",
+                        new
+                        {
+                            created = DateTime.Now.AddHours(-5),
+                            bodyText = "lorem ipsum",
+                            nodeTypeAlias = "CWS_Home"
+                        })
+                });
+
+
+                var searcher = indexer.Searcher;
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.287674516f, numberSortedResult.First().Score);
+            }
+        }
+
+        [Test]
+        public void Score_Freshness_Profile_Future_Date()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime")),
+                scoringProfiles: new List<IScoringProfile> { new FreshnessScoringProfile("created", new TimeSpan(1, 0, 0, 0), 1.5f) }))
+            {
+                indexer.IndexItems(new[]
+                {
+                    ValueSet.FromObject(123.ToString(), "content",
+                        new
+                        {
+                            created = DateTime.Now.AddHours(5),
+                            bodyText = "lorem ipsum",
+                            nodeTypeAlias = "CWS_Home"
+                        })
+                });
+
+
+                var searcher = indexer.Searcher;
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.191783011f, numberSortedResult.First().Score);
+            }
+        }
+
+        [Test]
+        public void Score_Freshness_Profile_Future_Date_With_Future_Duration()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime")),
+                scoringProfiles: new List<IScoringProfile> { new FreshnessScoringProfile("created", new TimeSpan(-1, 0, 0, 0), 1.5f) }))
+            {
+                indexer.IndexItems(new[]
+                {
+                    ValueSet.FromObject(123.ToString(), "content",
+                        new
+                        {
+                            created = DateTime.Now.AddHours(5),
+                            bodyText = "lorem ipsum",
+                            nodeTypeAlias = "CWS_Home"
+                        })
+                });
+
+                var searcher = indexer.Searcher;
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.287674516f, numberSortedResult.First().Score);
+            }
+        }
+
+        [Test]
+        public void Score_Freshness_Profile_Future_Duration()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime")),
+                scoringProfiles: new List<IScoringProfile> { new FreshnessScoringProfile("created", new TimeSpan(-1, 0, 0, 0), 1.5f) }))
+            {
+                indexer.IndexItems(new[]
+                {
+                    ValueSet.FromObject(123.ToString(), "content",
+                        new
+                        {
+                            created = DateTime.Now.AddDays(-2),
+                            bodyText = "lorem ipsum",
+                            nodeTypeAlias = "CWS_Home"
+                        })
+                });
+
+                var searcher = indexer.Searcher;
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.191783011f, numberSortedResult.First().Score);
+            }
+        }
+
+        [Test]
+        public void Score_Freshness_Add_On_Searcher()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(
+                luceneDir,
+                analyzer,
+                new FieldDefinitionCollection(new FieldDefinition("created", "datetime"))))
+            {
+                indexer.IndexItems(new[]
+                {
+                ValueSet.FromObject(123.ToString(), "content",
+                    new
+                    {
+                        created = DateTime.Now.AddDays(-2),
+                        bodyText = "lorem ipsum",
+                        nodeTypeAlias = "CWS_Home"
+                    })
+            });
+
+                var searcher = indexer.Searcher;
+
+                searcher.AddScoringProfile(new FreshnessScoringProfile("created", new TimeSpan(-1, 0, 0, 0), 1.5f));
+
+                var numberSortedCriteria = searcher.CreateQuery()
+                    .Field("bodyText", "ipsum");
+
+                var numberSortedResult = numberSortedCriteria
+                    .Execute();
+
+                Assert.AreEqual(0.191783011f, numberSortedResult.First().Score);
+            }
+        }
+    }
+}

--- a/src/Examine.Test/ExamineBaseTest.cs
+++ b/src/Examine.Test/ExamineBaseTest.cs
@@ -8,6 +8,7 @@ using Examine.Lucene;
 using Moq;
 using Examine.Lucene.Directories;
 using System.Collections.Generic;
+using Examine.Lucene.Scoring;
 
 namespace Examine.Test
 {
@@ -25,7 +26,7 @@ namespace Examine.Test
         [TearDown]
         public virtual void TearDown() => _loggerFactory.Dispose();
 
-        public TestIndex GetTestIndex(Directory d, Analyzer analyzer, FieldDefinitionCollection fieldDefinitions = null, IndexDeletionPolicy indexDeletionPolicy = null, IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null)
+        public TestIndex GetTestIndex(Directory d, Analyzer analyzer, FieldDefinitionCollection fieldDefinitions = null, IndexDeletionPolicy indexDeletionPolicy = null, IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null, IList<IScoringProfile> scoringProfiles = null)
             => new TestIndex(
                 _loggerFactory,
                 Mock.Of<IOptionsMonitor<LuceneDirectoryIndexOptions>>(x => x.Get(TestIndex.TestIndexName) == new LuceneDirectoryIndexOptions
@@ -34,7 +35,8 @@ namespace Examine.Test
                     DirectoryFactory = new GenericDirectoryFactory(_ => d),
                     Analyzer = analyzer,
                     IndexDeletionPolicy = indexDeletionPolicy,
-                    IndexValueTypesFactory = indexValueTypesFactory
+                    IndexValueTypesFactory = indexValueTypesFactory,
+                    ScoreProfiles = scoringProfiles
                 }));
 
         public TestIndex GetTestIndex(IndexWriter writer)


### PR DESCRIPTION
Just raising this pull request to get some feedback and opinions on the best approach to adding the ability to provide custom score queries to a Lucene search.

Idea is to allow global configuration of scoring queries on the LuceneIndexOptions, while also also scoring per searcher when creating a new instance to add to the ExamineManager and also adding them just before building a query directly on a searcher.

On executing the main query it is nested inside any score queries that have been added before being passed on to the LuceneSearchExecutor.

The code is just a very rough stab at a first pass to implement the ability to have custom score queries and already has areas of improvement such as:
- Is the IScoringProfile interface really needed would just building up a collection of CustomScoreQuery class be enough
- Change the score query list so that a searcher is give its own copy and not have the list pass by ref all the way down