### PR TITLE
Additional ServiceCollection extension methods

### DIFF
--- a/src/Examine.Host/ServicesCollectionExtensions.cs
+++ b/src/Examine.Host/ServicesCollectionExtensions.cs
@@ -28,8 +28,20 @@ namespace Examine
             FieldDefinitionCollection fieldDefinitions = null,
             Analyzer analyzer = null,
             IValueSetValidator validator = null,
-            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null,
-            FacetsConfig facetsConfig = null)
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null)
+            => serviceCollection.AddExamineLuceneIndex<LuceneIndex>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig: null);
+
+        /// <summary>
+        /// Registers a file system based Lucene Examine index
+        /// </summary>
+        public static IServiceCollection AddExamineLuceneIndex(
+            this IServiceCollection serviceCollection,
+            string name,
+            FieldDefinitionCollection fieldDefinitions,
+            Analyzer analyzer,
+            IValueSetValidator validator,
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory,
+            FacetsConfig facetsConfig)
             => serviceCollection.AddExamineLuceneIndex<LuceneIndex>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig);
 
         /// <summary>
@@ -41,8 +53,22 @@ namespace Examine
             FieldDefinitionCollection fieldDefinitions = null,
             Analyzer analyzer = null,
             IValueSetValidator validator = null,
-            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null,
-            FacetsConfig facetsConfig = null)
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null)
+            where TIndex : LuceneIndex
+            => serviceCollection.AddExamineLuceneIndex<TIndex, FileSystemDirectoryFactory>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig: null);
+
+
+        /// <summary>
+        /// Registers a file system based Lucene Examine index
+        /// </summary>
+        public static IServiceCollection AddExamineLuceneIndex<TIndex>(
+            this IServiceCollection serviceCollection,
+            string name,
+            FieldDefinitionCollection fieldDefinitions,
+            Analyzer analyzer,
+            IValueSetValidator validator,
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory,
+            FacetsConfig facetsConfig)
             where TIndex : LuceneIndex
             => serviceCollection.AddExamineLuceneIndex<TIndex, FileSystemDirectoryFactory>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig);
 
@@ -55,8 +81,22 @@ namespace Examine
             FieldDefinitionCollection fieldDefinitions = null,
             Analyzer analyzer = null,
             IValueSetValidator validator = null,
-            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null,
-            FacetsConfig facetsConfig = null)
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory = null)
+            where TIndex : LuceneIndex
+            where TDirectoryFactory : class, IDirectoryFactory
+        => serviceCollection.AddExamineLuceneIndex<TIndex, TDirectoryFactory>(name, fieldDefinitions, analyzer, validator, indexValueTypesFactory, facetsConfig: null);
+
+        /// <summary>
+        /// Registers an Examine index
+        /// </summary>
+        public static IServiceCollection AddExamineLuceneIndex<TIndex, TDirectoryFactory>(
+            this IServiceCollection serviceCollection,
+            string name,
+            FieldDefinitionCollection fieldDefinitions,
+            Analyzer analyzer,
+            IValueSetValidator validator,
+            IReadOnlyDictionary<string, IFieldValueTypeFactory> indexValueTypesFactory,
+            FacetsConfig facetsConfig)
             where TIndex : LuceneIndex
             where TDirectoryFactory : class, IDirectoryFactory
         {


### PR DESCRIPTION
These overloads allow for backwards compatibility between v3 and v4 when used inside Umbraco - allowing a v4 package to be substituted without re-compiling the entirety of Umbraco.

Reason:
Even though the new `FacetsConfig` parameter is optional and has a default value provided, existing packages that are built against v3 fail to bind to this method, producing a System.MissingMethodException:

```
System.MissingMethodException: Method not found: 'Microsoft.Extensions.DependencyInjection.IServiceCollection Examine.ServicesCollectionExtensions.AddExamineLuceneIndex(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.String, Examine.FieldDefinitionCollection, Lucene.Net.Analysis.Analyzer, Examine.IValueSetValidator, System.Collections.Generic.IReadOnlyDictionary`2<System.String,Examine.Lucene.IFieldValueTypeFactory>)'.
   at Umbraco.Cms.Infrastructure.Examine.DependencyInjection.UmbracoBuilderExtensions.AddExamineIndexes(IUmbracoBuilder umbracoBuilder)
```

By changing the new parameter to be made available as a traditional overload instead of an optional parameter, the original method signature is kept the same and is found via reflection.

