### PR TITLE
Allow mix of single objects and enumerables in valueset

### DIFF
--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -147,12 +148,23 @@ namespace Examine
 
         /// <summary>
         /// Helper method to return IEnumerable from a single
+        /// If object passed in is also enumerable
         /// </summary>
         /// <param name="i"></param>
         /// <returns></returns>
         private static IEnumerable<object> Yield(object i)
         {
-            yield return i;
+            if (i is IEnumerable enumerable)
+            {
+                foreach (var element in enumerable)
+                {
+                    yield return element;
+                }
+            }
+            else
+            {
+                yield return i;
+            }
         }
 
         /// <summary>

--- a/src/Examine.Core/ValueSet.cs
+++ b/src/Examine.Core/ValueSet.cs
@@ -154,7 +154,11 @@ namespace Examine
         /// <returns></returns>
         private static IEnumerable<object> Yield(object i)
         {
-            if (i is IEnumerable enumerable)
+            if (i is string)
+            {
+                yield return i;
+            }
+            else if (i is IEnumerable enumerable)
             {
                 foreach (var element in enumerable)
                 {

--- a/src/Examine.Test/Examine.Core/ValueSetTests.cs
+++ b/src/Examine.Test/Examine.Core/ValueSetTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Examine.Test.Examine.Core
+{
+    [TestFixture]
+    public class ValueSetTests
+    {
+
+        [Test]
+        public void TestYieldConvertsSingleObjectsToEnumerable()
+        {
+            /* Includes implicit test that String (which is technically IEnumerable<char>)
+             *  gets passed through as a single object - NOT as multiple chars
+             */
+
+            IDictionary<string, object> input = new Dictionary<string, object>()
+            {
+                {"boolean", false},
+                {"int", 1},
+                {"float", 1.2f},
+                {"double", 1.2d},
+                {"long", 45678923456345L},
+                {"datetime", DateTime.Today},
+                {"string", "A test sentence"}
+            };
+
+            var sut = new ValueSet("id", "category", "", input);
+
+            foreach (var key in input.Keys)
+            {
+                object[] value = sut.Values[key].ToArray();
+                Assert.IsTrue(value.Length == 1);
+                Assert.AreEqual(value[0], input[key]);
+            }
+        }
+
+        [Test]
+        public void TestYieldPassesEnumerationsThrough()
+        {
+
+            IDictionary<string, object> input = new Dictionary<string, object>()
+            {
+                {"booleanArray", new bool[] { false, true, true }},
+                {"intArray", new int[] {1, 2, 3}},
+                {"floatArray", new float[] {1.0f, 1.1f, 1.2f}},
+                {"doubleArray", new double[] { 123456789.123456789d, 7654321.7654321d}},
+                {"longArray", new long[] { 123456789012345678L, 876543210987654321L}},
+                {"datetimeArray", new DateTime[] { DateTime.Today, DateTime.MinValue }},
+                {"objectArray", new object[] { false, 123, 1.2f, 123456789.123456789d, 123456789012345678L, DateTime.Today, "a test string" }},
+                {"stringArray", new string[] { "first, second, third"}},
+                { "objectEnumerable", (IEnumerable<object>) (new object[] { "a", 123, DateTime.Today}).ToList()},
+                { "objectList", new List<object> { "a", 123, DateTime.MinValue}},
+                { "dictionary", new Dictionary<string, object>(){ { "a", 1}, {"b", 2}}}
+            };
+
+            var sut = new ValueSet("id", "category", "", input);
+
+
+            foreach (var key in input.Keys)
+            {
+                object[] expected = null;
+                // ArrayEnumerator does not inherit IEnumerable, so we have to
+                // test both options.
+                if (input[key] is IEnumerable enumerable)
+                    expected = enumerable.Cast<object>().ToArray();
+                else if (input[key] is Array array)
+                    expected = array.Cast<object>().ToArray();
+
+                object[] output = sut.Values[key].ToArray();
+
+                CollectionAssert.AreEqual(expected, output);
+            }
+        }
+
+
+        [Test]
+        public void TestYieldPassesBothSingleAndMultipleItems()
+        {
+
+            IDictionary<string, object> input = new Dictionary<string, object>()
+            {
+                {"boolean", false},
+                {"int", 1},
+                {"float", 1.2f},
+                {"double", 1.2d},
+                {"long", 45678923456345L},
+                {"datetime", DateTime.Today},
+                {"string", "A test sentence"},
+                {"intArray", new int[] {1, 2, 3}},
+                {"objectArray", new object[] { false, 123, 1.2f, 123456789.123456789d, 123456789012345678L, DateTime.Today, "a test string" }},
+                {"stringArray", new string[] { "first, second, third"}},
+                { "objectList", new List<object> { "a", 123, DateTime.MinValue}},
+            };
+
+            var sut = new ValueSet("id", "category", "", input);
+
+
+            foreach (var key in input.Keys)
+            {
+                object[] expected = null;
+                // ArrayEnumerator does not inherit IEnumerable, so we have to
+                // test both options.
+                if (input[key] is string s)
+                    expected = new object[] { s };
+                else if (input[key] is IEnumerable enumerable)
+                    expected = enumerable.Cast<object>().ToArray();
+                else if (input[key] is Array array)
+                    expected = array.Cast<object>().ToArray();
+                else
+                    expected = new object[] { input[key] };
+
+                object[] output = sut.Values[key].ToArray();
+
+                CollectionAssert.AreEqual(expected, output);
+
+                Assert.IsNotNull(sut.Values[key] as IEnumerable<object>);
+            }
+        }
+
+
+    }
+}

--- a/src/Examine.Test/Examine.Core/ValueSetTests.cs
+++ b/src/Examine.Test/Examine.Core/ValueSetTests.cs
@@ -14,7 +14,7 @@ namespace Examine.Test.Examine.Core
     {
 
         [Test]
-        public void TestYieldConvertsSingleObjectsToEnumerable()
+        public void Given_SingleValues_When_Yielding_ThenConvertsToEnumerableOfSingleValues()
         {
             /* Includes implicit test that String (which is technically IEnumerable<char>)
              *  gets passed through as a single object - NOT as multiple chars
@@ -42,7 +42,7 @@ namespace Examine.Test.Examine.Core
         }
 
         [Test]
-        public void TestYieldPassesEnumerationsThrough()
+        public void Given_Enumerable_When_Yielding_ThenConvertsToEnumerable()
         {
 
             IDictionary<string, object> input = new Dictionary<string, object>()
@@ -81,7 +81,7 @@ namespace Examine.Test.Examine.Core
 
 
         [Test]
-        public void TestYieldPassesBothSingleAndMultipleItems()
+        public void Given_SingleAndEnumerableValues_When_Yeilding_ThenConvertsToEnumerable()
         {
 
             IDictionary<string, object> input = new Dictionary<string, object>()


### PR DESCRIPTION
This change updates the yield helper method that converts an `IDictionary<string, object>` to an `IDictionary<string, IEnumerable<object>>`.

This allows for greater flexibility when constructing valueSets. Currently, if you have a single field that requires multiple values (say for faceting), you must use the `IDictionary<string, IEnumerable<object>>` overload and wrap all your fields in arrays or other enumerable structures. This change means that you can submit an array for a field and it will be automatically interpreted correctly.

Before - with all other fields wrapped in arrays:
```
var multiValues = new Dictionary<string, IEnumerable<object>>
{
    // this is a special field used to display the content name in the Examine dashboard
    [UmbracoExamineFieldNames.NodeNameFieldName] = new[] { content.Name! },
    // add the fields you want in the index
    ["id"] = new List<object> { content.Id },
    ["udi"] = new[] { content.GetUdi() },
    ...
    // GetTags returns an array of tags
    ["tags"] = GetTags(content)
};
```

After - with mix of single objects and arrays:

```
var indexValues = new Dictionary<string, object>
{
    // this is a special field used to display the content name in the Examine dashboard
    [UmbracoExamineFieldNames.NodeNameFieldName] = content.Name!,
    // add the fields you want in the index
    ["id"] = content.Id,
    ["udi"] = content.GetUdi(),
    ...
   // GetTags return an array of tags
    ["tags"] = GetTags(content),
};
```
