### PR TITLE
CI - Add your build.yml change to the release branch 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ on:
       - 'v*'
   pull_request:
     branches:
-      - '*'  
+      - 'master'
+      - 'dev'
+      - 'release/*'
 
 jobs:
   build:
@@ -88,6 +90,3 @@ jobs:
       with:
         name: examine-nuget-${{ env.GitVersion_SemVer }}
         path:  ${{ github.workspace }}/_NugetOutput/*.*
-
-    - name: Publish to GitHub Packages
-      run: dotnet nuget push "${{ github.workspace }}/_NugetOutput/*.nupkg"  --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/shazwazza/index.json"


### PR DESCRIPTION
We need to add this change to the release branches because otherwise the action won't run on the PRs to `release/3.0` @Shazwazza 