### PR TITLE
Add Developer Guide to docs site

### DIFF
--- a/docs/developerguides/buildtest.md
+++ b/docs/developerguides/buildtest.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Build and Test
+permalink: /devbuildtest
+uid: devbuildtest
+order: 1
+---
+
+Build and Test
+===
+
+1. Clone the Git repository from https://github.com/Shazwazza/Examine.
+2. Open src\Examine.sln using Visual Studio
+3. Build the solution
+4. Run the test suite

--- a/docs/developerguides/codestructure.md
+++ b/docs/developerguides/codestructure.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: Code Structure
+permalink: /devcodestructure
+uid: devcodestructure
+order: 1
+---
+
+Code Structure
+===
+
+Examine is structured into the following projects
+
+## src/Examine/Examine.csproj
+
+Extension methods to easily set up Examine Lucene in an ASP.NET Core project.
+
+## src/Examine.Core/Examine.Core.csproj
+
+Core Examine abstractions to support multiple search engine providers.
+
+## src/Examine.Lucene/Examine.Lucene.csproj
+
+Lucene.NET provider that implements the core Examine abstractions.
+
+## src/Examine.Tests/Examine.Tests.csproj
+
+Tests for the Lucene.NET provider that implements the core Examine abstractions.
+
+## src/Examine.Web.Demo/Examine.Web.Demo.csproj
+
+An ASP.NET Core Razor Pages application that demos the features and usage of the Examine libraries.

--- a/docs/developerguides/docsite.md
+++ b/docs/developerguides/docsite.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Documentation Site
+permalink: /devdocsite
+uid: devdocsite
+order: 1
+---
+
+Documentation Site
+===
+
+The Examine documentation site is generated using [docfx](https://github.com/dotnet/docfx) using Markdown syntax.
+
+## Contributing to documentation
+The easiest way to get started is to edit an existing page by clicking the Improve this Doc link that appears on the top right of each page. This will open up code editing on Github with a pull request to the correct branch.
+
+## Building documentation
+
+1. Download [docfx](https://github.com/dotnet/docfx/releases).
+2. Unzip the release and add the folder to your system path variables.
+3. Open a terminal, for example PowerShell or the VS Code terminal.
+4. Change directory to /docs
+5. Enter "docfx" into the terminal and press enter. This will build the docs into the /docs/_site folder. Alternatively enter "docfx --serve" to build the documentation and serve the site. By default, the site is hosted on http://localhost:8080

--- a/docs/developerguides/roadmap.md
+++ b/docs/developerguides/roadmap.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: Roadmap
+permalink: /devroadmap
+uid: devroadmap
+order: 1
+---
+
+Examine.Lucene Roadmap
+===
+
+This page covers the roadmap for the core Examine abstractions and the Examine.Lucene Lucene.NET based provider.
+
+## Ongoing and future work
+
+- [ ] [Facet Deep Paging](https://github.com/Shazwazza/Examine/pull/321)
+- [ ] [Hierarchical Faceting API (Taxonomy)](https://github.com/Shazwazza/Examine/pull/323)
+- [ ] [Suggestions API and Spellchecking API](https://github.com/Shazwazza/Examine/pull/326)
+- [ ] [Similarity API (BM25)](https://github.com/Shazwazza/Examine/pull/327)
+- [ ] [GeoSpatial API](https://github.com/Shazwazza/Examine/pull/328)
+- [ ] [Custom Scoring API](https://github.com/Shazwazza/Examine/pull/338)
+
+## Past and completed work
+
+- [x] [Nullable Support](https://github.com/Shazwazza/Examine/pull/313)
+- [x] [Faceting API (SortedDocValues)](https://github.com/Shazwazza/Examine/pull/311)
+- [x] [Docfx website](https://github.com/Shazwazza/Examine/pull/322)
+- [x] [Deep Paging](https://github.com/Shazwazza/Examine/pull/320)
+
+## Release Notes
+
+### Examine 3.1
+[Examine 3.1 Release Notes](https://github.com/Shazwazza/Examine/releases/tag/v3.1.0)

--- a/docs/developerguides/toc.yml
+++ b/docs/developerguides/toc.yml
@@ -1,0 +1,8 @@
+- name: Build and Test
+  href: buildtest.md
+- name: Code Structure
+  href: codestructure.md
+- name: Documentation Site
+  href: docsite.md
+- name: Roadmap
+  href: roadmap.md

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -35,7 +35,9 @@
           "toc.yml",
           "*.md",
           "docs-v1-v2/**.md",
-          "docs-v1-v2/**/toc.yml"
+          "docs-v1-v2/**/toc.yml",
+          "developerguides/**.md",
+          "developerguides/**/toc.yml"
         ]
       }
     ],

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,7 +1,9 @@
-- name: Articles
+- name: User Guide
   href: articles/
 - name: Api Documentation
   href: api/
   homepage: api/index.md
+- name: Developer Guide
+  href: developerguides/
 - name: Source Code
   href: https://github.com/Shazwazza/Examine


### PR DESCRIPTION
Renames the Articles section to User Guide (no links break).
Adds a developer guide section