### PR TITLE
V4.0 Facet Drill Down and Drill Sideways support

### DIFF
--- a/src/Examine.Core/PublicAPI.Unshipped.txt
+++ b/src/Examine.Core/PublicAPI.Unshipped.txt
@@ -70,6 +70,10 @@ Examine.Search.FloatRange.Max.get -> float
 Examine.Search.FloatRange.MaxInclusive.get -> bool
 Examine.Search.FloatRange.Min.get -> float
 Examine.Search.FloatRange.MinInclusive.get -> bool
+Examine.Search.IDrillDownQueryDimensions
+Examine.Search.IDrillDownQueryDimensions.AddDimension(string! dimensionName, params string![]! paths) -> Examine.Search.IDrillDownQueryDimensions!
+Examine.Search.IDrillSideways
+Examine.Search.IDrillSideways.SetTopN(int topN) -> Examine.Search.IDrillSideways!
 Examine.Search.IExamineValueBoosted
 Examine.Search.IExamineValueBoosted.Boost.get -> float
 Examine.Search.IFaceting
@@ -79,6 +83,7 @@ Examine.Search.IFacetLabel.Components.get -> string![]!
 Examine.Search.IFacetLabel.Length.get -> int
 Examine.Search.IFacetLabel.Subpath(int length) -> Examine.Search.IFacetLabel!
 Examine.Search.IFacetOperations
+Examine.Search.IFacetOperations.FacetAllDimensions(int maxCount) -> Examine.Search.IFacetOperations!
 Examine.Search.IFacetOperations.FacetDoubleRange(string! field, params Examine.Search.DoubleRange[]! doubleRanges) -> Examine.Search.IFacetOperations!
 Examine.Search.IFacetOperations.FacetFloatRange(string! field, params Examine.Search.FloatRange[]! floatRanges) -> Examine.Search.IFacetOperations!
 Examine.Search.IFacetOperations.FacetLongRange(string! field, params Examine.Search.Int64Range[]! longRanges) -> Examine.Search.IFacetOperations!
@@ -102,7 +107,12 @@ Examine.Search.Int64Range.Max.get -> long
 Examine.Search.Int64Range.MaxInclusive.get -> bool
 Examine.Search.Int64Range.Min.get -> long
 Examine.Search.Int64Range.MinInclusive.get -> bool
+Examine.Search.IOrdering.SetSearchAfter(Examine.Search.SearchAfter! searchAfter) -> Examine.Search.IOrdering!
+Examine.Search.IQuery.DrillDownQuery(System.Action<Examine.Search.IDrillDownQueryDimensions!>! dimensions, System.Func<Examine.Search.INestedQuery!, Examine.Search.INestedBooleanOperation!>? baseQuery = null, System.Action<Examine.Search.IDrillSideways!>? drillSideways = null, Examine.Search.BooleanOperation defaultOp = Examine.Search.BooleanOperation.Or) -> Examine.Search.IOrdering!
 Examine.Search.OrderingExtensions
+Examine.Search.SearchAfter
+Examine.Search.SearchAfter.SearchAfter(string! searchAfter) -> void
+Examine.Search.SearchAfter.Value.get -> string!
 Examine.ValueSet.Category.get -> string!
 Examine.ValueSet.ItemType.get -> string!
 Examine.ValueSet.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<object!>!>!

--- a/src/Examine.Core/Search/IDrillDownQueryDimensions.cs
+++ b/src/Examine.Core/Search/IDrillDownQueryDimensions.cs
@@ -1,0 +1,18 @@
+﻿namespace Examine.Search
+{
+    /// <summary>
+    /// Drill-down Query Dimensions
+    /// </summary>
+    public interface IDrillDownQueryDimensions
+    {
+        /// <summary>
+        /// Adds one dimension of drill-downs.
+        /// Repeated dimensions are OR'd with the previous contraints for the dimension.
+        /// All demensions are AND'd againt each other and the base query.
+        /// </summary>
+        /// <param name="dimensionName">Dimension Name</param>
+        /// <param name="paths">Facet Category Paths</param>
+        /// <returns></returns>
+        IDrillDownQueryDimensions AddDimension(string dimensionName, params string[] paths);
+    }
+}

--- a/src/Examine.Core/Search/IDrillSideways.cs
+++ b/src/Examine.Core/Search/IDrillSideways.cs
@@ -1,0 +1,15 @@
+namespace Examine.Search
+{
+    /// <summary>
+    /// Drill Sideways Options
+    /// </summary>
+    public interface IDrillSideways
+    {
+        /// <summary>
+        /// Set the number of Top Documents
+        /// </summary>
+        /// <param name="topN">Number of Top Documents</param>
+        /// <returns></returns>
+        IDrillSideways SetTopN(int topN);
+    }
+}

--- a/src/Examine.Core/Search/IFacetOperations.cs
+++ b/src/Examine.Core/Search/IFacetOperations.cs
@@ -31,5 +31,12 @@ namespace Examine.Search
         /// Add a range facet to the current query
         /// </summary>
         IFacetOperations FacetLongRange(string field, params Int64Range[] longRanges);
+
+        /// <summary>
+        /// Return all Facet Dimensions that had hits
+        /// </summary>
+        /// <param name="maxCount">Maximum number of terms to return</param>
+        /// <returns></returns>
+        IFacetOperations FacetAllDimensions(int maxCount);
     }
 }

--- a/src/Examine.Core/Search/IOrdering.cs
+++ b/src/Examine.Core/Search/IOrdering.cs
@@ -40,6 +40,13 @@ namespace Examine.Search
         /// Return all fields in the index
         /// </summary>
         /// <returns></returns>
-        IOrdering SelectAllFields();        
+        IOrdering SelectAllFields();
+
+        /// <summary>
+        /// Set where to continue searching from
+        /// </summary>
+        /// <param name="searchAfter">Search After</param>
+        /// <returns></returns>
+        IOrdering SetSearchAfter(SearchAfter searchAfter);
     }
 }

--- a/src/Examine.Core/Search/IQuery.cs
+++ b/src/Examine.Core/Search/IQuery.cs
@@ -138,8 +138,19 @@ namespace Examine.Search
         /// <summary>
         /// Query for drill-down over facet categories. Call dimensions.Add() for each group of categories to drill-down over
         /// </summary>
-        /// <param name="dimensions"></param>
+        /// <param name="dimensions">Facet Dimensions to Drill Down</param>
+        /// <param name="drillSideways">Facet Dimensions to Drill Sideways</param>
         /// <returns></returns>
-        IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions);
+        IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
+
+        /// <summary>
+        /// Query for drill-down over facet categories. Call dimensions.Add() for each group of categories to drill-down over
+        /// </summary>
+        /// <param name="baseQuery">Base Query to Drill Down on</param>
+        /// <param name="dimensions">Facet Dimensions to Drill Down</param>
+        /// <param name="drillSideways">Facet Dimensions to Drill Sideways</param>
+        /// <param name="defaultOp">Base Query default Op</param>
+        /// <returns></returns>
+        IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Core/Search/IQuery.cs
+++ b/src/Examine.Core/Search/IQuery.cs
@@ -134,5 +134,12 @@ namespace Examine.Search
         /// <param name="maxInclusive"></param>
         /// <returns></returns>
         IBooleanOperation RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true) where T : struct;
+
+        /// <summary>
+        /// Query for drill-down over facet categories. Call dimensions.Add() for each group of categories to drill-down over
+        /// </summary>
+        /// <param name="dimensions"></param>
+        /// <returns></returns>
+        IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions);
     }
 }

--- a/src/Examine.Core/Search/IQuery.cs
+++ b/src/Examine.Core/Search/IQuery.cs
@@ -141,7 +141,7 @@ namespace Examine.Search
         /// <param name="dimensions">Facet Dimensions to Drill Down</param>
         /// <param name="drillSideways">Facet Dimensions to Drill Sideways</param>
         /// <returns></returns>
-        IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
+        IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
 
         /// <summary>
         /// Query for drill-down over facet categories. Call dimensions.Add() for each group of categories to drill-down over
@@ -151,6 +151,6 @@ namespace Examine.Search
         /// <param name="drillSideways">Facet Dimensions to Drill Sideways</param>
         /// <param name="defaultOp">Base Query default Op</param>
         /// <returns></returns>
-        IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
+        IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Core/Search/IQuery.cs
+++ b/src/Examine.Core/Search/IQuery.cs
@@ -138,19 +138,11 @@ namespace Examine.Search
         /// <summary>
         /// Query for drill-down over facet categories. Call dimensions.Add() for each group of categories to drill-down over
         /// </summary>
-        /// <param name="dimensions">Facet Dimensions to Drill Down</param>
-        /// <param name="drillSideways">Facet Dimensions to Drill Sideways</param>
-        /// <returns></returns>
-        IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
-
-        /// <summary>
-        /// Query for drill-down over facet categories. Call dimensions.Add() for each group of categories to drill-down over
-        /// </summary>
         /// <param name="baseQuery">Base Query to Drill Down on</param>
         /// <param name="dimensions">Facet Dimensions to Drill Down</param>
         /// <param name="drillSideways">Facet Dimensions to Drill Sideways</param>
         /// <param name="defaultOp">Base Query default Op</param>
         /// <returns></returns>
-        IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
+        IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Func<INestedQuery, INestedBooleanOperation>? baseQuery = null, Action<IDrillSideways>? drillSideways = null, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Core/Search/SearchAfter.cs
+++ b/src/Examine.Core/Search/SearchAfter.cs
@@ -1,0 +1,22 @@
+namespace Examine.Search
+{
+    /// <summary>
+    /// Options for Searching After. Used for efficent deep paging.
+    /// </summary>
+    public class SearchAfter
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="searchAfter">String representing the search after value</param>
+        public SearchAfter(string searchAfter)
+        {
+            Value = searchAfter;
+        }
+
+        /// <summary>
+        /// String representing the search after value
+        /// </summary>
+        public string Value { get; }
+    }
+}

--- a/src/Examine.Lucene/Indexing/FullTextType.cs
+++ b/src/Examine.Lucene/Indexing/FullTextType.cs
@@ -11,6 +11,7 @@ using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Facet;
 using Lucene.Net.Facet.SortedSet;
+using Lucene.Net.Facet.Taxonomy;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Microsoft.Extensions.Logging;
@@ -134,7 +135,15 @@ namespace Examine.Lucene.Indexing
                         Field.Store.YES));
                 }
 
-                if (_isFacetable && _taxonomyIndex)
+                if (_isFacetable && _taxonomyIndex && value is IFacetLabel taxonomyFacetLabel)
+                {
+                    doc.Add(new FacetField(taxonomyFacetLabel.Components[0], taxonomyFacetLabel.Components.AsSpan().Slice(1).ToArray()));
+                }
+                else if (_isFacetable && !_taxonomyIndex && value is IFacetLabel facetLabel)
+                {
+                    doc.Add(new SortedSetDocValuesFacetField(facetLabel.Components[0], facetLabel.Components[1]));
+                }
+                else if(_isFacetable && _taxonomyIndex)
                 {
                     doc.Add(new FacetField(FieldName, str));
                 }

--- a/src/Examine.Lucene/Indexing/FullTextType.cs
+++ b/src/Examine.Lucene/Indexing/FullTextType.cs
@@ -11,6 +11,7 @@ using Lucene.Net.Analysis.TokenAttributes;
 using Lucene.Net.Documents;
 using Lucene.Net.Facet;
 using Lucene.Net.Facet.SortedSet;
+using Lucene.Net.Facet.Taxonomy;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Microsoft.Extensions.Logging;
@@ -132,7 +133,15 @@ namespace Examine.Lucene.Indexing
                         Field.Store.YES));
                 }
 
-                if (_isFacetable && _taxonomyIndex)
+                if (_isFacetable && _taxonomyIndex && value is IFacetLabel taxonomyFacetLabel)
+                {
+                    doc.Add(new FacetField(taxonomyFacetLabel.Components[0], taxonomyFacetLabel.Components.AsSpan().Slice(1).ToArray()));
+                }
+                else if (_isFacetable && !_taxonomyIndex && value is IFacetLabel facetLabel)
+                {
+                    doc.Add(new SortedSetDocValuesFacetField(facetLabel.Components[0], facetLabel.Components[1]));
+                }
+                else if(_isFacetable && _taxonomyIndex)
                 {
                     doc.Add(new FacetField(FieldName, str));
                 }

--- a/src/Examine.Lucene/PublicAPI.Unshipped.txt
+++ b/src/Examine.Lucene/PublicAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 #nullable enable
 abstract Examine.Lucene.Providers.BaseLuceneSearcher.Dispose() -> void
+abstract Examine.Lucene.Search.LuceneBooleanOperationBase.SetSearchAfter(Examine.Search.SearchAfter! searchAfter) -> Examine.Search.IOrdering!
 abstract Examine.Lucene.Search.LuceneBooleanOperationBase.WithFacets(System.Action<Examine.Search.IFacetOperations!>! facets) -> Examine.Search.IQueryExecutor!
+abstract Examine.Lucene.Search.LuceneDrillDownQueryDimensionBase.Apply(Lucene.Net.Facet.DrillDownQuery! drillDownQuery) -> void
+abstract Examine.Lucene.Search.LuceneSearchQueryBase.DrillDownQuery(System.Action<Examine.Search.IDrillDownQueryDimensions!>! dimensions, System.Func<Examine.Search.INestedQuery!, Examine.Search.INestedBooleanOperation!>? baseQuery = null, System.Action<Examine.Search.IDrillSideways!>? drillSideways = null, Examine.Search.BooleanOperation defaultOp = Examine.Search.BooleanOperation.Or) -> Examine.Search.IOrdering!
 Examine.Lucene.Directories.FileSystemDirectoryFactory
 Examine.Lucene.Directories.FileSystemDirectoryFactory.CreateTaxonomyDirectory(Examine.Lucene.Providers.LuceneIndex! luceneIndex, bool forceUnlock) -> Lucene.Net.Store.Directory!
 Examine.Lucene.Directories.FileSystemDirectoryFactory.FileSystemDirectoryFactory(System.IO.DirectoryInfo! baseDir, Examine.Lucene.Directories.ILockFactory! lockFactory, Microsoft.Extensions.Options.IOptionsMonitor<Examine.Lucene.LuceneDirectoryIndexOptions!>! indexOptions) -> void
@@ -96,10 +99,12 @@ Examine.Lucene.Search.FacetQueryField.FacetQueryField(Examine.Lucene.Search.Face
 Examine.Lucene.Search.FacetQueryField.MaxCount(int count) -> Examine.Search.IFacetQueryField!
 Examine.Lucene.Search.FacetQueryField.SetPath(params string![]! path) -> Examine.Search.IFacetQueryField!
 Examine.Lucene.Search.IFacetExtractionContext
+Examine.Lucene.Search.IFacetExtractionContext.DrillSidewaysResultFacets.get -> Lucene.Net.Facet.Facets?
 Examine.Lucene.Search.IFacetExtractionContext.FacetConfig.get -> Lucene.Net.Facet.FacetsConfig!
 Examine.Lucene.Search.IFacetExtractionContext.FacetsCollector.get -> Lucene.Net.Facet.FacetsCollector!
 Examine.Lucene.Search.IFacetExtractionContext.GetFacetCounts(string! facetIndexFieldName, bool isTaxonomyIndexed) -> Lucene.Net.Facet.Facets!
 Examine.Lucene.Search.IFacetExtractionContext.SearcherReference.get -> Examine.Lucene.Search.ISearcherReference!
+Examine.Lucene.Search.IFacetExtractionContext.SortedSetReaderState.get -> Lucene.Net.Facet.SortedSet.SortedSetDocValuesReaderState?
 Examine.Lucene.Search.IFacetField
 Examine.Lucene.Search.IFacetField.ExtractFacets(Examine.Lucene.Search.IFacetExtractionContext! facetExtractionContext) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, Examine.Search.IFacetResult!>>!
 Examine.Lucene.Search.IFacetField.FacetField.get -> string!
@@ -109,11 +114,28 @@ Examine.Lucene.Search.ITaxonomySearchContext
 Examine.Lucene.Search.ITaxonomySearchContext.GetTaxonomyAndSearcher() -> Examine.Lucene.Search.ITaxonomySearcherReference!
 Examine.Lucene.Search.ITaxonomySearcherReference
 Examine.Lucene.Search.ITaxonomySearcherReference.TaxonomyReader.get -> Lucene.Net.Facet.Taxonomy.Directory.DirectoryTaxonomyReader!
+Examine.Lucene.Search.LuceneBooleanOperationBase.OpBaseQuery(System.Func<Lucene.Net.Search.Query!, Lucene.Net.Search.Query!>! baseQueryBuilder, System.Func<Examine.Search.INestedQuery!, Examine.Search.INestedBooleanOperation!>! inner, Examine.Search.BooleanOperation outerOp, Examine.Search.BooleanOperation? defaultInnerOp = null) -> Examine.Lucene.Search.LuceneBooleanOperationBase!
+Examine.Lucene.Search.LuceneDrillDownQueryDimensionBase
+Examine.Lucene.Search.LuceneDrillDownQueryDimensionBase.DimensionName.get -> string!
+Examine.Lucene.Search.LuceneDrillDownQueryDimensionBase.LuceneDrillDownQueryDimensionBase(string! dimensionName) -> void
+Examine.Lucene.Search.LuceneDrillDownQueryDimensionPath
+Examine.Lucene.Search.LuceneDrillDownQueryDimensionPath.LuceneDrillDownQueryDimensionPath(string! dimensionName, params string![]! paths) -> void
+Examine.Lucene.Search.LuceneDrillDownQueryDimensionPath.Paths.get -> string![]!
+Examine.Lucene.Search.LuceneDrillDownQueryDimensions
+Examine.Lucene.Search.LuceneDrillDownQueryDimensions.AddDimension(string! dimensionName, params string![]! paths) -> Examine.Search.IDrillDownQueryDimensions!
+Examine.Lucene.Search.LuceneDrillDownQueryDimensions.Apply(Lucene.Net.Facet.DrillDownQuery! drillDownQuery) -> void
+Examine.Lucene.Search.LuceneDrillDownQueryDimensions.LuceneDrillDownQueryDimensions() -> void
+Examine.Lucene.Search.LuceneDrillDownQueryDrillSideways
+Examine.Lucene.Search.LuceneDrillDownQueryDrillSideways.LuceneDrillDownQueryDrillSideways() -> void
+Examine.Lucene.Search.LuceneDrillDownQueryDrillSideways.SetTopN(int topN) -> Examine.Search.IDrillSideways!
+Examine.Lucene.Search.LuceneDrillDownQueryDrillSideways.TopN.get -> int
 Examine.Lucene.Search.LuceneFacetExtractionContext
+Examine.Lucene.Search.LuceneFacetExtractionContext.DrillSidewaysResultFacets.get -> Lucene.Net.Facet.Facets?
 Examine.Lucene.Search.LuceneFacetExtractionContext.FacetConfig.get -> Lucene.Net.Facet.FacetsConfig!
 Examine.Lucene.Search.LuceneFacetExtractionContext.FacetsCollector.get -> Lucene.Net.Facet.FacetsCollector!
-Examine.Lucene.Search.LuceneFacetExtractionContext.LuceneFacetExtractionContext(Lucene.Net.Facet.FacetsCollector! facetsCollector, Examine.Lucene.Search.ISearcherReference! searcherReference, Lucene.Net.Facet.FacetsConfig! facetConfig) -> void
+Examine.Lucene.Search.LuceneFacetExtractionContext.LuceneFacetExtractionContext(Lucene.Net.Facet.FacetsCollector! facetsCollector, Examine.Lucene.Search.ISearcherReference! searcherReference, Lucene.Net.Facet.FacetsConfig! facetConfig, Lucene.Net.Facet.Facets? drillSidewaysResultFacets) -> void
 Examine.Lucene.Search.LuceneFacetExtractionContext.SearcherReference.get -> Examine.Lucene.Search.ISearcherReference!
+Examine.Lucene.Search.LuceneFacetExtractionContext.SortedSetReaderState.get -> Lucene.Net.Facet.SortedSet.SortedSetDocValuesReaderState?
 Examine.Lucene.Search.LuceneFacetLabel
 Examine.Lucene.Search.LuceneFacetLabel.CompareTo(Examine.Search.IFacetLabel? other) -> int
 Examine.Lucene.Search.LuceneFacetLabel.Components.get -> string![]!
@@ -123,6 +145,7 @@ Examine.Lucene.Search.LuceneFacetLabel.Subpath(int length) -> Examine.Search.IFa
 Examine.Lucene.Search.LuceneFacetOperation
 Examine.Lucene.Search.LuceneFacetOperation.Execute(Examine.Search.QueryOptions? options = null) -> Examine.ISearchResults!
 Examine.Lucene.Search.LuceneFacetOperation.Facet(string! field, System.Action<Examine.Search.IFacetQueryField!>? facetConfiguration = null) -> Examine.Search.IFacetOperations!
+Examine.Lucene.Search.LuceneFacetOperation.FacetAllDimensions(int maxCount) -> Examine.Search.IFacetOperations!
 Examine.Lucene.Search.LuceneFacetOperation.FacetDoubleRange(string! field, params Examine.Search.DoubleRange[]! doubleRanges) -> Examine.Search.IFacetOperations!
 Examine.Lucene.Search.LuceneFacetOperation.FacetFloatRange(string! field, params Examine.Search.FloatRange[]! floatRanges) -> Examine.Search.IFacetOperations!
 Examine.Lucene.Search.LuceneFacetOperation.FacetLongRange(string! field, params Examine.Search.Int64Range[]! longRanges) -> Examine.Search.IFacetOperations!
@@ -133,6 +156,15 @@ Examine.Lucene.Search.LuceneFacetSamplingQueryOptions.LuceneFacetSamplingQueryOp
 Examine.Lucene.Search.LuceneFacetSamplingQueryOptions.LuceneFacetSamplingQueryOptions(int sampleSize, long seed) -> void
 Examine.Lucene.Search.LuceneFacetSamplingQueryOptions.SampleSize.get -> int
 Examine.Lucene.Search.LuceneFacetSamplingQueryOptions.Seed.get -> long
+Examine.Lucene.Search.LuceneFacetSelectionOptions
+Examine.Lucene.Search.LuceneFacetSelectionOptions.FacetAllFieldsWithHits.get -> bool
+Examine.Lucene.Search.LuceneFacetSelectionOptions.FacetAllFieldsWithHits.set -> void
+Examine.Lucene.Search.LuceneFacetSelectionOptions.FacetAllFieldsWithHitsMaxCount.get -> int
+Examine.Lucene.Search.LuceneFacetSelectionOptions.FacetAllFieldsWithHitsMaxCount.set -> void
+Examine.Lucene.Search.LuceneFacetSelectionOptions.FacetFields.get -> System.Collections.Generic.IList<Examine.Lucene.Search.IFacetField!>!
+Examine.Lucene.Search.LuceneFacetSelectionOptions.FacetFields.set -> void
+Examine.Lucene.Search.LuceneFacetSelectionOptions.LuceneFacetSelectionOptions() -> void
+Examine.Lucene.Search.LuceneQuery.DrillDownQuery(System.Action<Examine.Search.IDrillDownQueryDimensions!>! dimensions, System.Func<Examine.Search.INestedQuery!, Examine.Search.INestedBooleanOperation!>? baseQuery = null, System.Action<Examine.Search.IDrillSideways!>? drillSideways = null, Examine.Search.BooleanOperation defaultOp = Examine.Search.BooleanOperation.Or) -> Examine.Search.IOrdering!
 Examine.Lucene.Search.LuceneQueryOptions.FacetRandomSampling.get -> Examine.Lucene.Search.LuceneFacetSamplingQueryOptions?
 Examine.Lucene.Search.LuceneQueryOptions.LuceneQueryOptions(int skip, int take = 100, Examine.Lucene.Search.SearchAfterOptions? searchAfter = null, bool trackDocumentScores = false, bool trackDocumentMaxScore = false, int skipTakeMaxResults = 10000, bool autoCalculateSkipTakeMaxResults = false, Examine.Lucene.Search.LuceneFacetSamplingQueryOptions? facetSampling = null) -> void
 Examine.Lucene.Search.LuceneSearchQuery.LuceneSearchQuery(Examine.Lucene.Search.ISearchContext! searchContext, string? category, Lucene.Net.Analysis.Analyzer! analyzer, Examine.Lucene.Search.LuceneSearchOptions! searchOptions, Examine.Search.BooleanOperation occurance, Lucene.Net.Facet.FacetsConfig! facetsConfig) -> void
@@ -140,7 +172,9 @@ Examine.Lucene.Search.LuceneSearchResults.Facets.get -> System.Collections.Gener
 Examine.Lucene.Search.LuceneSearchResults.LuceneSearchResults(System.Collections.Generic.IReadOnlyCollection<Examine.ISearchResult!>! results, int totalItemCount, System.Collections.Generic.IReadOnlyDictionary<string!, Examine.Search.IFacetResult!>! facets, float maxScore, Examine.Lucene.Search.SearchAfterOptions? searchAfterOptions) -> void
 Examine.Lucene.Search.LuceneSearchResults.MaxScore.get -> float
 Examine.Lucene.Search.LuceneSearchResults.SearchAfter.get -> Examine.Lucene.Search.SearchAfterOptions?
+Examine.Lucene.Search.SearchAfterOptions.SearchAfterOptions(Examine.Search.SearchAfter! searchAfter) -> void
 Examine.Lucene.Search.SearchAfterOptions.ShardIndex.get -> int
+Examine.Lucene.Search.SearchAfterOptions.ToSearchAfter() -> Examine.Search.SearchAfter!
 Examine.Lucene.Search.SearchContext.SearchContext(Lucene.Net.Search.SearcherManager! searcherManager, Examine.Lucene.FieldValueTypeCollection! fieldValueTypeCollection, bool isNrt) -> void
 Examine.Lucene.Search.TaxonomySearchContext
 Examine.Lucene.Search.TaxonomySearchContext.GetFieldValueType(string! fieldName) -> Examine.Lucene.Indexing.IIndexFieldValueType!
@@ -162,8 +196,11 @@ override Examine.Lucene.Indexing.SingleType.AddValue(Lucene.Net.Documents.Docume
 override Examine.Lucene.Providers.LuceneIndex.PerformDeleteFromIndex(System.Collections.Generic.IEnumerable<string!>! itemIds, System.Action<Examine.IndexOperationEventArgs!>? onComplete) -> void
 override Examine.Lucene.Providers.LuceneIndex.PerformIndexItems(System.Collections.Generic.IEnumerable<Examine.ValueSet!>! values, System.Action<Examine.IndexOperationEventArgs!>? onComplete) -> void
 override Examine.Lucene.Providers.MultiIndexSearcher.Dispose() -> void
+override Examine.Lucene.Search.LuceneBooleanOperation.SetSearchAfter(Examine.Search.SearchAfter! searchAfter) -> Examine.Search.IOrdering!
 override Examine.Lucene.Search.LuceneBooleanOperation.WithFacets(System.Action<Examine.Search.IFacetOperations!>! facets) -> Examine.Search.IQueryExecutor!
+override Examine.Lucene.Search.LuceneDrillDownQueryDimensionPath.Apply(Lucene.Net.Facet.DrillDownQuery! drillDownQuery) -> void
 override Examine.Lucene.Search.LuceneFacetOperation.ToString() -> string!
+override Examine.Lucene.Search.LuceneSearchQuery.DrillDownQuery(System.Action<Examine.Search.IDrillDownQueryDimensions!>! dimensions, System.Func<Examine.Search.INestedQuery!, Examine.Search.INestedBooleanOperation!>? baseQuery = null, System.Action<Examine.Search.IDrillSideways!>? drillSideways = null, Examine.Search.BooleanOperation defaultOp = Examine.Search.BooleanOperation.Or) -> Examine.Search.IOrdering!
 static Examine.Lucene.FacetExtensions.GetFacet(this Examine.ISearchResults! searchResults, string! field) -> Examine.Search.IFacetResult?
 static Examine.Lucene.FacetExtensions.GetFacets(this Examine.ISearchResults! searchResults) -> System.Collections.Generic.IEnumerable<Examine.Search.IFacetResult!>!
 static Examine.Lucene.Search.LuceneSearchExtensions.ExecuteWithLucene(this Examine.Search.IQueryExecutor! queryExecutor, Examine.Search.QueryOptions? options = null) -> Examine.Lucene.Search.ILuceneSearchResults!
@@ -178,6 +215,7 @@ virtual Examine.Lucene.Providers.LuceneIndex.CreateIndexWriter(Lucene.Net.Store.
 virtual Examine.Lucene.Providers.LuceneIndex.TaxonomySearcher.get -> Examine.Lucene.Providers.ILuceneTaxonomySearcher?
 virtual Examine.Lucene.Providers.LuceneIndex.UpdateLuceneDocument(Lucene.Net.Index.Term! term, Lucene.Net.Documents.Document! doc) -> long?
 virtual Examine.Lucene.Search.LuceneFacetExtractionContext.GetFacetCounts(string! facetIndexFieldName, bool isTaxonomyIndexed) -> Lucene.Net.Facet.Facets!
+virtual Examine.Lucene.Search.LuceneSearchQuery.SetSearchAfter(Examine.Search.SearchAfter! searchAfter) -> void
 virtual Examine.Lucene.Search.LuceneSearchQueryBase.GetFieldInternalQuery(string! fieldName, Examine.Search.IExamineValue! fieldValue) -> Lucene.Net.Search.Query?
 virtual Examine.Lucene.Search.TaxonomySearcherReference.Dispose(bool disposing) -> void
 Examine.Lucene.LuceneIndexOptions.NrtCacheMaxCachedMB.get -> double

--- a/src/Examine.Lucene/Search/IFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/IFacetExtractionContext.cs
@@ -24,9 +24,14 @@ namespace Examine.Lucene.Search
         ISearcherReference SearcherReference { get; }
 
         /// <summary>
-        /// SortedSetReaderState
+        /// SortedSetReaderState (Non taxonomy indexed)
         /// </summary>
         SortedSetDocValuesReaderState? SortedSetReaderState { get; }
+
+        /// <summary>
+        /// Drill Sideways Result Facets
+        /// </summary>
+        Facets? DrillSidewaysResultFacets { get; }
 
         /// <summary>
         /// Get the facet counts for the faceted field

--- a/src/Examine.Lucene/Search/IFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/IFacetExtractionContext.cs
@@ -1,4 +1,5 @@
 using Lucene.Net.Facet;
+using Lucene.Net.Facet.SortedSet;
 
 namespace Examine.Lucene.Search
 {
@@ -21,6 +22,11 @@ namespace Examine.Lucene.Search
         /// Index Searcher Reference
         /// </summary>
         ISearcherReference SearcherReference { get; }
+
+        /// <summary>
+        /// SortedSetReaderState
+        /// </summary>
+        SortedSetDocValuesReaderState? SortedSetReaderState { get; }
 
         /// <summary>
         /// Get the facet counts for the faceted field

--- a/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperation.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Examine.Lucene.Providers;
 using Examine.Search;
 using Lucene.Net.Search;
 
@@ -81,6 +80,13 @@ namespace Examine.Lucene.Search
             var luceneFacetOperation = new LuceneFacetOperation(_search);
             facets.Invoke(luceneFacetOperation);
             return luceneFacetOperation;
+        }
+
+        /// <inheritdoc/>
+        public override IOrdering SetSearchAfter(SearchAfter searchAfter)
+        {
+            _search.SetSearchAfter(searchAfter);
+            return this;
         }
     }
 }

--- a/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
+++ b/src/Examine.Lucene/Search/LuceneBooleanOperationBase.cs
@@ -118,6 +118,42 @@ namespace Examine.Lucene.Search
             return _search.LuceneQuery(_search.Queries.Pop(), outerOp);
         }
 
+        /// <summary>
+        /// Used to add a operation
+        /// </summary>
+        /// <param name="baseQueryBuilder">Function that the base query will be passed into to create the outer query</param>
+        /// <param name="inner"></param>
+        /// <param name="outerOp"></param>
+        /// <param name="defaultInnerOp"></param>
+        /// <returns></returns>
+        protected internal LuceneBooleanOperationBase OpBaseQuery(
+            Func<Query,Query> baseQueryBuilder,
+            Func<INestedQuery, INestedBooleanOperation> inner,
+            BooleanOperation outerOp,
+            BooleanOperation? defaultInnerOp = null)
+        {
+            _search.Queries.Push(new BooleanQuery());
+
+            //change the default inner op if specified
+            var currentOp = _search.BooleanOperation;
+            if (defaultInnerOp != null)
+            {
+                _search.BooleanOperation = defaultInnerOp.Value;
+            }
+
+            //run the inner search
+            inner(_search);
+
+            //reset to original op if specified
+            if (defaultInnerOp != null)
+            {
+                _search.BooleanOperation = currentOp;
+            }
+            var baseBoolQuery = _search.Queries.Pop();
+            var baseQuery = baseQueryBuilder(baseBoolQuery);
+            return _search.LuceneQuery(baseQuery, outerOp);
+        }
+
         /// <inheritdoc/>
         public abstract ISearchResults Execute(QueryOptions? options = null);
 
@@ -138,5 +174,8 @@ namespace Examine.Lucene.Search
 
         /// <inheritdoc/>
         public abstract IQueryExecutor WithFacets(Action<IFacetOperations> facets);
+
+        /// <inheritdoc/>
+        public abstract IOrdering SetSearchAfter(SearchAfter searchAfter);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensionBase.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensionBase.cs
@@ -1,0 +1,30 @@
+using Lucene.Net.Facet;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Lucene DrillDown Query Dimensions base
+    /// </summary>
+    public abstract class LuceneDrillDownQueryDimensionBase
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="dimensionName">Dimension Name</param>
+        public LuceneDrillDownQueryDimensionBase(string dimensionName)
+        {
+            DimensionName = dimensionName;
+        }
+
+        /// <summary>
+        /// Dimension Name
+        /// </summary>
+        public string DimensionName { get; }
+
+        /// <summary>
+        /// Add the dimension to the Drill-down Query
+        /// </summary>
+        /// <param name="drillDownQuery"></param>
+        public abstract void Apply(DrillDownQuery drillDownQuery);
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensionPath.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensionPath.cs
@@ -1,0 +1,31 @@
+﻿using Lucene.Net.Facet;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Drill-down Query Dimension + Path
+    /// </summary>
+    public class LuceneDrillDownQueryDimensionPath : LuceneDrillDownQueryDimensionBase
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="dimensionName">Dimension Name</param>
+        /// <param name="paths">Facet Category Paths</param>
+        public LuceneDrillDownQueryDimensionPath(string dimensionName, params string[] paths) : base(dimensionName)
+        {
+            Paths = paths;
+        }
+
+        /// <summary>
+        /// Facet Category Paths
+        /// </summary>
+        public string[] Paths { get; }
+
+        /// <inheritdoc/>
+        public override void Apply(DrillDownQuery drillDownQuery)
+        {
+            drillDownQuery.Add(DimensionName, Paths);
+        }
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensionPath.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensionPath.cs
@@ -1,4 +1,4 @@
-﻿using Lucene.Net.Facet;
+using Lucene.Net.Facet;
 
 namespace Examine.Lucene.Search
 {
@@ -23,9 +23,6 @@ namespace Examine.Lucene.Search
         public string[] Paths { get; }
 
         /// <inheritdoc/>
-        public override void Apply(DrillDownQuery drillDownQuery)
-        {
-            drillDownQuery.Add(DimensionName, Paths);
-        }
+        public override void Apply(DrillDownQuery drillDownQuery) => drillDownQuery.Add(DimensionName, Paths);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
@@ -9,7 +9,7 @@ namespace Examine.Lucene.Search
     /// </summary>
     public class LuceneDrillDownQueryDimensions : IDrillDownQueryDimensions
     {
-        private Dictionary<string, List<LuceneDrillDownQueryDimensionBase>> _dimensions = new Dictionary<string, List<LuceneDrillDownQueryDimensionBase>>();
+        private readonly Dictionary<string, List<LuceneDrillDownQueryDimensionBase>> _dimensions = new Dictionary<string, List<LuceneDrillDownQueryDimensionBase>>();
 
         /// <inheritdoc/>
         public IDrillDownQueryDimensions AddDimension(string dimensionName, params string[] paths)

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
@@ -10,6 +10,12 @@ namespace Examine.Lucene.Search
     public class LuceneDrillDownQueryDimensions : IDrillDownQueryDimensions
     {
         private readonly Dictionary<string, List<LuceneDrillDownQueryDimensionBase>> _dimensions = new Dictionary<string, List<LuceneDrillDownQueryDimensionBase>>();
+        private readonly FacetsConfig _facetsConfig;
+
+        public LuceneDrillDownQueryDimensions(FacetsConfig facetsConfig)
+        {
+            _facetsConfig = facetsConfig;
+        }
 
         /// <inheritdoc/>
         public IDrillDownQueryDimensions AddDimension(string dimensionName, params string[] paths)
@@ -19,7 +25,6 @@ namespace Examine.Lucene.Search
             {
                 _dimensions[dimensionName] = new List<LuceneDrillDownQueryDimensionBase>();
             }
-
             _dimensions[dimensionName].Add(dimension);
             return this;
         }

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Examine.Search;
+using Lucene.Net.Facet;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Lucene DrillDown Query Dimensions
+    /// </summary>
+    public class LuceneDrillDownQueryDimensions : IDrillDownQueryDimensions
+    {
+        private Dictionary<string, List<LuceneDrillDownQueryDimensionBase>> _dimensions = new Dictionary<string, List<LuceneDrillDownQueryDimensionBase>>();
+
+        /// <inheritdoc/>
+        public IDrillDownQueryDimensions AddDimension(string dimensionName, params string[] paths)
+        {
+            var dimension = new LuceneDrillDownQueryDimensionPath(dimensionName, paths);
+            if (!_dimensions.TryGetValue(dimensionName, out var dims))
+            {
+                _dimensions[dimensionName] = new List<LuceneDrillDownQueryDimensionBase>();
+            }
+
+            _dimensions[dimensionName].Add(dimension);
+            return this;
+        }
+
+        /// <summary>
+        /// Add the dimension to the Drill-down Query
+        /// </summary>
+        /// <param name="drillDownQuery"></param>
+        public void Apply(DrillDownQuery drillDownQuery)
+        {
+            foreach (var item in _dimensions)
+            {
+                foreach (var dim in item.Value)
+                {
+                    dim.Apply(drillDownQuery);
+                }
+            }
+        }
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDimensions.cs
@@ -10,12 +10,7 @@ namespace Examine.Lucene.Search
     public class LuceneDrillDownQueryDimensions : IDrillDownQueryDimensions
     {
         private readonly Dictionary<string, List<LuceneDrillDownQueryDimensionBase>> _dimensions = new Dictionary<string, List<LuceneDrillDownQueryDimensionBase>>();
-        private readonly FacetsConfig _facetsConfig;
-
-        public LuceneDrillDownQueryDimensions(FacetsConfig facetsConfig)
-        {
-            _facetsConfig = facetsConfig;
-        }
+        
 
         /// <inheritdoc/>
         public IDrillDownQueryDimensions AddDimension(string dimensionName, params string[] paths)

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDrillSideways.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDrillSideways.cs
@@ -1,0 +1,22 @@
+using Examine.Search;
+
+namespace Examine.Lucene.Search
+{
+    /// <summary>
+    /// Lucene Drill Sideways
+    /// </summary>
+    public class LuceneDrillDownQueryDrillSideways : IDrillSideways
+    {
+        /// <summary>
+        /// Top N Documents
+        /// </summary>
+        public int TopN { get; private set; }
+
+        /// <inheritdoc/>
+        public IDrillSideways SetTopN(int topN)
+        {
+            TopN = topN;
+            return this;
+        }
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneDrillDownQueryDrillSideways.cs
+++ b/src/Examine.Lucene/Search/LuceneDrillDownQueryDrillSideways.cs
@@ -10,7 +10,7 @@ namespace Examine.Lucene.Search
         /// <summary>
         /// Top N Documents
         /// </summary>
-        public int TopN { get; private set; }
+        public int TopN { get; private set; } = 10;
 
         /// <inheritdoc/>
         public IDrillSideways SetTopN(int topN)

--- a/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
@@ -10,10 +10,12 @@ namespace Examine.Lucene.Search
     {
 
         /// <inheritdoc/>
-        public LuceneFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcherReference, FacetsConfig facetConfig)
+        public LuceneFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcherReference, FacetsConfig facetConfig,
+            Facets? drillSidewaysResultFacets)
         {
             FacetsCollector = facetsCollector;
             FacetConfig = facetConfig;
+            DrillSidewaysResultFacets = drillSidewaysResultFacets;
             SearcherReference = searcherReference;
         }
 
@@ -22,6 +24,9 @@ namespace Examine.Lucene.Search
 
         /// <inheritdoc/>
         public FacetsConfig FacetConfig { get; }
+
+        /// <inheritdoc/>
+        public Facets? DrillSidewaysResultFacets { get; }
 
         /// <inheritdoc/>
         public ISearcherReference SearcherReference { get; }

--- a/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
@@ -37,6 +37,10 @@ namespace Examine.Lucene.Search
         /// <inheritdoc/>
         public virtual Facets GetFacetCounts(string facetIndexFieldName, bool isTaxonomyIndexed)
         {
+            if(DrillSidewaysResultFacets is not null)
+            {
+                return DrillSidewaysResultFacets;
+            }
             if (isTaxonomyIndexed)
             {
                 if (SearcherReference is ITaxonomySearcherReference taxonomySearcher)

--- a/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetExtractionContext.cs
@@ -9,8 +9,6 @@ namespace Examine.Lucene.Search
     public class LuceneFacetExtractionContext : IFacetExtractionContext
     {
 
-        private SortedSetDocValuesReaderState? _sortedSetReaderState = null;
-
         /// <inheritdoc/>
         public LuceneFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcherReference, FacetsConfig facetConfig)
         {
@@ -29,6 +27,9 @@ namespace Examine.Lucene.Search
         public ISearcherReference SearcherReference { get; }
 
         /// <inheritdoc/>
+        public SortedSetDocValuesReaderState? SortedSetReaderState { get; private set; }
+
+        /// <inheritdoc/>
         public virtual Facets GetFacetCounts(string facetIndexFieldName, bool isTaxonomyIndexed)
         {
             if (isTaxonomyIndexed)
@@ -41,11 +42,11 @@ namespace Examine.Lucene.Search
             }
             else
             {
-                if (_sortedSetReaderState == null || !_sortedSetReaderState.Field.Equals(facetIndexFieldName))
+                if (SortedSetReaderState == null || !SortedSetReaderState.Field.Equals(facetIndexFieldName))
                 {
-                    _sortedSetReaderState = new DefaultSortedSetDocValuesReaderState(SearcherReference.IndexSearcher.IndexReader, facetIndexFieldName);
+                    SortedSetReaderState = new DefaultSortedSetDocValuesReaderState(SearcherReference.IndexSearcher.IndexReader, facetIndexFieldName);
                 }
-                return new SortedSetDocValuesFacetCounts(_sortedSetReaderState, FacetsCollector);
+                return new SortedSetDocValuesFacetCounts(SortedSetReaderState, FacetsCollector);
             }
         }
     }

--- a/src/Examine.Lucene/Search/LuceneFacetOperation.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetOperation.cs
@@ -42,5 +42,8 @@ namespace Examine.Lucene.Search
 
         /// <inheritdoc/>
         public override string ToString() => _search.ToString();
+
+        /// <inheritdoc/>
+        public IFacetOperations FacetAllDimensions(int maxCount) => _search.FacetAllDimensionsInternal(maxCount);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneFacetSelectionOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetSelectionOptions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Examine.Lucene.Search
+{
+    public class LuceneFacetSelectionOptions
+    {
+        public IList<IFacetField> FacetFields { get; set; } = new List<IFacetField>();
+
+        public bool FacetAllFieldsWithHits { get; set; }
+
+        public int FacetAllFieldsWithHitsMaxCount { get; set; }= 10;
+    }
+}

--- a/src/Examine.Lucene/Search/LuceneFacetSelectionOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneFacetSelectionOptions.cs
@@ -6,12 +6,25 @@ using System.Threading.Tasks;
 
 namespace Examine.Lucene.Search
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class LuceneFacetSelectionOptions
     {
+        /// <summary>
+        /// 
+        /// </summary>
         public IList<IFacetField> FacetFields { get; set; } = new List<IFacetField>();
 
+
+        /// <summary>
+        /// 
+        /// </summary>
         public bool FacetAllFieldsWithHits { get; set; }
 
-        public int FacetAllFieldsWithHitsMaxCount { get; set; }= 10;
+        /// <summary>
+        /// 
+        /// </summary>
+        public int FacetAllFieldsWithHitsMaxCount { get; set; } = 10;
     }
 }

--- a/src/Examine.Lucene/Search/LuceneQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneQuery.cs
@@ -137,12 +137,12 @@ namespace Examine.Lucene.Search
             => _search.RangeQueryInternal(fields, min, max, minInclusive: minInclusive, maxInclusive: maxInclusive, _occurrence);
 
         /// <inheritdoc/>
-        public IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways)
+        public IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways)
             => _search.DrillDownQueryInternal(dimensions, drillSideways, _occurrence);
 
 
         /// <inheritdoc/>
-        public IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or)
+        public IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or)
             => _search.DrillDownQueryInternal(inner, dimensions, drillSideways, defaultOp, _occurrence);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneQuery.cs
@@ -137,12 +137,7 @@ namespace Examine.Lucene.Search
             => _search.RangeQueryInternal(fields, min, max, minInclusive: minInclusive, maxInclusive: maxInclusive, _occurrence);
 
         /// <inheritdoc/>
-        public IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways)
-            => _search.DrillDownQueryInternal(dimensions, drillSideways, _occurrence);
-
-
-        /// <inheritdoc/>
-        public IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or)
-            => _search.DrillDownQueryInternal(inner, dimensions, drillSideways, defaultOp, _occurrence);
+        public IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Func<INestedQuery, INestedBooleanOperation>? baseQuery = null, Action<IDrillSideways>? drillSideways = null, BooleanOperation defaultOp = BooleanOperation.Or) =>
+            _search.DrillDownQueryInternal(baseQuery, dimensions, drillSideways, defaultOp, _occurrence);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneQuery.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Examine.Search;
-using Lucene.Net.Facet.Range;
-using Lucene.Net.Index;
-using Lucene.Net.QueryParsers.Surround.Query;
 using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
@@ -141,7 +137,12 @@ namespace Examine.Lucene.Search
             => _search.RangeQueryInternal(fields, min, max, minInclusive: minInclusive, maxInclusive: maxInclusive, _occurrence);
 
         /// <inheritdoc/>
-        public IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions)
-            => _search.DrillDownQueryInternal(dimensions, _occurrence);
+        public IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways)
+            => _search.DrillDownQueryInternal(dimensions, drillSideways, _occurrence);
+
+
+        /// <inheritdoc/>
+        public IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or)
+            => _search.DrillDownQueryInternal(inner, dimensions, drillSideways, defaultOp, _occurrence);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneQuery.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Examine.Search;
 using Lucene.Net.Facet.Range;
+using Lucene.Net.Index;
+using Lucene.Net.QueryParsers.Surround.Query;
 using Lucene.Net.Search;
 
 namespace Examine.Lucene.Search
@@ -137,5 +139,9 @@ namespace Examine.Lucene.Search
         /// <inheritdoc/>
         INestedBooleanOperation INestedQuery.RangeQuery<T>(string[] fields, T? min, T? max, bool minInclusive, bool maxInclusive)
             => _search.RangeQueryInternal(fields, min, max, minInclusive: minInclusive, maxInclusive: maxInclusive, _occurrence);
+
+        /// <inheritdoc/>
+        public IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions)
+            => _search.DrillDownQueryInternal(dimensions, _occurrence);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -27,10 +27,11 @@ namespace Examine.Lucene.Search
         private readonly ISet<string>? _fieldsToLoad;
         private readonly IEnumerable<IFacetField>? _facetFields;
         private readonly FacetsConfig? _facetsConfig;
+        private readonly SearchAfterOptions _searchAfter;
         private int? _maxDoc;
 
         internal LuceneSearchExecutor(QueryOptions? options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext,
-            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig)
+            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig, SearchAfterOptions searchAfter)
         {
             _options = options ?? QueryOptions.Default;
             _luceneQueryOptions = _options as LuceneQueryOptions;
@@ -40,6 +41,7 @@ namespace Examine.Lucene.Search
             _searchContext = searchContext ?? throw new ArgumentNullException(nameof(searchContext));
             _facetFields = facetFields;
             _facetsConfig = facetsConfig;
+            _searchAfter = _luceneQueryOptions?.SearchAfter ?? searchAfter;
         }
 
         private int MaxDoc
@@ -108,10 +110,11 @@ namespace Examine.Lucene.Search
                     sort = new Sort(sortFields);
                     sort.Rewrite(searcher.IndexSearcher);
                 }
-                if (_luceneQueryOptions != null && _luceneQueryOptions.SearchAfter != null)
+
+                if (_searchAfter != null)
                 {
                     //The document to find results after.
-                    scoreDocAfter = GetScoreDocAfter(_luceneQueryOptions.SearchAfter);
+                    scoreDocAfter = GetScoreDocAfter(_searchAfter);
 
                     // We want to only collect only the actual number of hits we want to take after the last document. We don't need to collect all previous/next docs.
                     numHits = _options.Take >= 1 ? _options.Take : QueryOptions.DefaultMaxResults;

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -163,8 +163,8 @@ namespace Examine.Lucene.Search
                     DrillSideways ds;
                     if (taxonomySearcherReference is null)
                     {
-                        var facetExtractionContext = GetFacetExtractionContext(facetsCollector, searcher);
-                        ds = new DrillSideways(searcher.IndexSearcher, _facetsConfig, facetExtractionContext.SortedSetReaderState);
+                        var sortedSetReaderState = new DefaultSortedSetDocValuesReaderState(searcher.IndexSearcher.IndexReader);
+                        ds = new DrillSideways(searcher.IndexSearcher, _facetsConfig, sortedSetReaderState);
                     }
                     else
                     {
@@ -247,7 +247,22 @@ namespace Examine.Lucene.Search
                 var searchAfterOptions = GetSearchAfterOptions(topDocs);
                 float maxScore = topDocs.MaxScore;
 
-                var facets = ExtractFacets(facetsCollector, searcher);
+
+                IFacetExtractionContext? facetExtractionContext = null;
+                if (facetsCollector is not null)
+                {
+                    facetExtractionContext = GetFacetExtractionContext(facetsCollector, searcher, drillSidewaysResult?.Facets);
+                }
+
+                IReadOnlyDictionary<string, IFacetResult> facets;
+                if (facetExtractionContext is null)
+                {
+                    facets = new Dictionary<string, IFacetResult>(0, StringComparer.InvariantCultureIgnoreCase);
+                }
+                else
+                {
+                    facets = ExtractFacets(facetExtractionContext);
+                }
 
                 return new LuceneSearchResults(results, totalItemCount, facets, maxScore, searchAfterOptions);
             }
@@ -309,10 +324,16 @@ namespace Examine.Lucene.Search
             return null;
         }
 
-        private IReadOnlyDictionary<string, IFacetResult> ExtractFacets(FacetsCollector? facetsCollector, ISearcherReference searcher)
+        private IReadOnlyDictionary<string, IFacetResult> ExtractFacets(IFacetExtractionContext facetExtractionContext)
         {
+
             var facets = new Dictionary<string, IFacetResult>(StringComparer.InvariantCultureIgnoreCase);
-            if (facetsCollector == null || _facetFields is null || !_facetFields.Any())
+            if (facetExtractionContext == null)
+            {
+                return facets;
+            }
+
+            if (_facetFields is null || !_facetFields.Any())
             {
                 return facets;
             }
@@ -329,7 +350,6 @@ namespace Examine.Lucene.Search
                         throw new InvalidOperationException("Facets Config not set. Please use a constructor that passes all parameters");
                     }
 
-                    var facetExtractionContext = GetFacetExtractionContext(facetsCollector, searcher);
 
                     var fieldFacets = facetValueType.ExtractFacets(facetExtractionContext, field);
                     foreach (var fieldFacet in fieldFacets)
@@ -343,7 +363,8 @@ namespace Examine.Lucene.Search
             return facets;
         }
 
-        private LuceneFacetExtractionContext GetFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcher) => new LuceneFacetExtractionContext(facetsCollector, searcher, _facetsConfig);
+        private LuceneFacetExtractionContext GetFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcher, Facets? drillSidewaysResultFacets) =>
+            new LuceneFacetExtractionContext(facetsCollector, searcher, _facetsConfig, drillSidewaysResultFacets);
 
 
         private LuceneSearchResult GetSearchResult(ScoreDoc scoreDoc, IndexSearcher luceneSearcher)

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -102,8 +102,6 @@ namespace Examine.Lucene.Search
                     searcher = _searchContext.GetSearcher();
                 }
 
-            using (var searcher = _searchContext.GetSearcher())
-            {
                 var maxSkipTakeDataSetSize = _luceneQueryOptions?.AutoCalculateSkipTakeMaxResults ?? false
                     ? GetMaxDoc()
                     : _luceneQueryOptions?.SkipTakeMaxResults ?? QueryOptions.AbsoluteMaxResults;
@@ -146,7 +144,7 @@ namespace Examine.Lucene.Search
                     (_facetFieldsSelectionOptions.FacetFields.Any() || _facetFieldsSelectionOptions.FacetAllFieldsWithHits)
                     && _luceneQueryOptions != null && _luceneQueryOptions.FacetRandomSampling != null)
                 {
-                    var facetsCollectors = new RandomSamplingFacetsCollector(_luceneQueryOptions.FacetRandomSampling.SampleSize, _luceneQueryOptions.FacetRandomSampling.Seed);
+                    facetsCollector = new RandomSamplingFacetsCollector(_luceneQueryOptions.FacetRandomSampling.SampleSize, _luceneQueryOptions.FacetRandomSampling.Seed);
                 }
                 else if (_facetFieldsSelectionOptions != null &&
                     (_facetFieldsSelectionOptions.FacetFields.Any() || _facetFieldsSelectionOptions.FacetAllFieldsWithHits))
@@ -339,14 +337,17 @@ namespace Examine.Lucene.Search
             {
                 // May not be the only Facets implementation that could be supported
                 var facetCounts = facetExtractionContext.DrillSidewaysResultFacets;
-                var luceneFacetResults = facetCounts.GetAllDims(_facetFieldsSelectionOptions.FacetAllFieldsWithHitsMaxCount);
-                Dictionary<string, IFacetResult> results = new Dictionary<string, IFacetResult>();
-                foreach (var luceneFacetResult in luceneFacetResults)
+                if (facetCounts != null)
                 {
-                    var facetAllResults = new KeyValuePair<string, IFacetResult>(luceneFacetResult.Dim, new Examine.Search.FacetResult(luceneFacetResult.LabelValues.Select(labelValue => new FacetValue(labelValue.Label, labelValue.Value) as IFacetValue)));
-                    results.Add(facetAllResults.Key, facetAllResults.Value);
+                    var luceneFacetResults = facetCounts.GetAllDims(_facetFieldsSelectionOptions.FacetAllFieldsWithHitsMaxCount);
+                    var results = new Dictionary<string, IFacetResult>();
+                    foreach (var luceneFacetResult in luceneFacetResults)
+                    {
+                        var facetAllResults = new KeyValuePair<string, IFacetResult>(luceneFacetResult.Dim, new Examine.Search.FacetResult(luceneFacetResult.LabelValues.Select(labelValue => new FacetValue(labelValue.Label, labelValue.Value) as IFacetValue)));
+                        results.Add(facetAllResults.Key, facetAllResults.Value);
+                    }
+                    return results;
                 }
-                return results;
             }
 
             if (!_facetFieldsSelectionOptions.FacetFields.Any())
@@ -379,9 +380,14 @@ namespace Examine.Lucene.Search
             return facets;
         }
 
-        private LuceneFacetExtractionContext GetFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcher, Facets? drillSidewaysResultFacets) =>
-            new LuceneFacetExtractionContext(facetsCollector, searcher, _facetsConfig, drillSidewaysResultFacets);
-
+        private LuceneFacetExtractionContext GetFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcher, Facets? drillSidewaysResultFacets)
+        {
+            if(_facetsConfig is null)
+            {
+                throw new InvalidOperationException("FacetsConfig is null");
+            }
+            return new LuceneFacetExtractionContext(facetsCollector, searcher, _facetsConfig, drillSidewaysResultFacets);
+        }
 
         private LuceneSearchResult GetSearchResult(ScoreDoc scoreDoc, IndexSearcher luceneSearcher)
         {

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Examine.Lucene.Indexing;
 using Examine.Search;
@@ -28,11 +29,13 @@ namespace Examine.Lucene.Search
         private readonly ISet<string>? _fieldsToLoad;
         private readonly IEnumerable<IFacetField>? _facetFields;
         private readonly FacetsConfig? _facetsConfig;
-        private readonly SearchAfterOptions _searchAfter;
+        private readonly LuceneDrillDownQueryDrillSideways? _drillDownQueryDrillSideways;
+        private readonly SearchAfterOptions? _searchAfter;
         private int? _maxDoc;
 
         internal LuceneSearchExecutor(QueryOptions? options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext,
-            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig, SearchAfterOptions searchAfter)
+            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig, SearchAfterOptions? searchAfter,
+            LuceneDrillDownQueryDrillSideways? drillDownQueryDrillSideways)
         {
             _options = options ?? QueryOptions.Default;
             _luceneQueryOptions = _options as LuceneQueryOptions;
@@ -42,6 +45,7 @@ namespace Examine.Lucene.Search
             _searchContext = searchContext ?? throw new ArgumentNullException(nameof(searchContext));
             _facetFields = facetFields;
             _facetsConfig = facetsConfig;
+            _drillDownQueryDrillSideways = drillDownQueryDrillSideways;
             _searchAfter = _luceneQueryOptions?.SearchAfter ?? searchAfter;
         }
 
@@ -84,6 +88,19 @@ namespace Examine.Lucene.Search
             Sort? sort = null;
             FieldDoc? scoreDocAfter = null;
             Filter? filter = null;
+            ISearcherReference? searcher = null;
+            ITaxonomySearcherReference? taxonomySearcherReference = null;
+            try
+            {
+                if (_searchContext is ITaxonomySearchContext taxonomySearchContext)
+                {
+                    taxonomySearcherReference = taxonomySearchContext.GetTaxonomyAndSearcher();
+                    searcher = taxonomySearcherReference;
+                }
+                else
+                {
+                    searcher = _searchContext.GetSearcher();
+                }
 
             using (var searcher = _searchContext.GetSearcher())
             {
@@ -134,7 +151,48 @@ namespace Examine.Lucene.Search
                     facetsCollector = new FacetsCollector();
                 }
 
-                if (scoreDocAfter != null && sort != null)
+                var drillDownQuery = _luceneQuery as DrillDownQuery;
+                if (drillDownQuery is null && _luceneQuery is BooleanQuery boolQuery)
+                {
+                    drillDownQuery = boolQuery.Clauses.Where(x => x.Query is DrillDownQuery).SingleOrDefault()?.Query as DrillDownQuery;
+                }
+
+                DrillSidewaysResult? drillSidewaysResult = null;
+                if (drillDownQuery is not null && _drillDownQueryDrillSideways != null)
+                {
+                    DrillSideways ds;
+                    if (taxonomySearcherReference is null)
+                    {
+                        var facetExtractionContext = GetFacetExtractionContext(facetsCollector, searcher);
+                        ds = new DrillSideways(searcher.IndexSearcher, _facetsConfig, facetExtractionContext.SortedSetReaderState);
+                    }
+                    else
+                    {
+                        ds = new DrillSideways(taxonomySearcherReference.IndexSearcher, _facetsConfig, taxonomySearcherReference.TaxonomyReader);
+                    }
+                    int drillSidewaysTopN = _drillDownQueryDrillSideways.TopN;
+                    bool doDocScores = true;
+                    bool doMaxScores = true;
+
+                    if (facetsCollector != null)
+                    {
+                        drillSidewaysResult = ds.Search(drillDownQuery, MultiCollector.Wrap(topDocsCollector, facetsCollector));
+                        if (sortFields.Length > 0)
+                        {
+                            topDocs = ((TopFieldCollector)topDocsCollector).GetTopDocs(_options.Skip, _options.Take);
+                        }
+                        else
+                        {
+                            topDocs = ((TopScoreDocCollector)topDocsCollector).GetTopDocs(_options.Skip, _options.Take);
+                        }
+                    }
+                    else
+                    {
+                        drillSidewaysResult = ds.Search(drillDownQuery, filter, scoreDocAfter, drillSidewaysTopN, sort, doDocScores, doMaxScores);
+                        topDocs = drillSidewaysResult.Hits;
+                    }
+                }
+                else if (scoreDocAfter != null && sort != null)
                 {
                     if (facetsCollector != null)
                     {
@@ -188,9 +246,14 @@ namespace Examine.Lucene.Search
                 }
                 var searchAfterOptions = GetSearchAfterOptions(topDocs);
                 float maxScore = topDocs.MaxScore;
+
                 var facets = ExtractFacets(facetsCollector, searcher);
 
                 return new LuceneSearchResults(results, totalItemCount, facets, maxScore, searchAfterOptions);
+            }
+            finally
+            {
+                searcher?.Dispose();
             }
         }
 
@@ -266,7 +329,7 @@ namespace Examine.Lucene.Search
                         throw new InvalidOperationException("Facets Config not set. Please use a constructor that passes all parameters");
                     }
 
-                    var facetExtractionContext = new LuceneFacetExtractionContext(facetsCollector, searcher, _facetsConfig);
+                    var facetExtractionContext = GetFacetExtractionContext(facetsCollector, searcher);
 
                     var fieldFacets = facetValueType.ExtractFacets(facetExtractionContext, field);
                     foreach (var fieldFacet in fieldFacets)
@@ -279,6 +342,9 @@ namespace Examine.Lucene.Search
 
             return facets;
         }
+
+        private LuceneFacetExtractionContext GetFacetExtractionContext(FacetsCollector facetsCollector, ISearcherReference searcher) => new LuceneFacetExtractionContext(facetsCollector, searcher, _facetsConfig);
+
 
         private LuceneSearchResult GetSearchResult(ScoreDoc scoreDoc, IndexSearcher luceneSearcher)
         {

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -28,10 +28,11 @@ namespace Examine.Lucene.Search
         private readonly ISet<string>? _fieldsToLoad;
         private readonly IEnumerable<IFacetField>? _facetFields;
         private readonly FacetsConfig? _facetsConfig;
+        private readonly SearchAfterOptions _searchAfter;
         private int? _maxDoc;
 
         internal LuceneSearchExecutor(QueryOptions? options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext,
-            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig)
+            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig, SearchAfterOptions searchAfter)
         {
             _options = options ?? QueryOptions.Default;
             _luceneQueryOptions = _options as LuceneQueryOptions;
@@ -41,6 +42,7 @@ namespace Examine.Lucene.Search
             _searchContext = searchContext ?? throw new ArgumentNullException(nameof(searchContext));
             _facetFields = facetFields;
             _facetsConfig = facetsConfig;
+            _searchAfter = _luceneQueryOptions?.SearchAfter ?? searchAfter;
         }
 
         /// <summary>
@@ -99,10 +101,10 @@ namespace Examine.Lucene.Search
                     sort.Rewrite(searcher.IndexSearcher);
                 }
 
-                if (_luceneQueryOptions != null && _luceneQueryOptions.SearchAfter != null)
+                if (_searchAfter != null)
                 {
                     //The document to find results after.
-                    scoreDocAfter = GetScoreDocAfter(_luceneQueryOptions.SearchAfter);
+                    scoreDocAfter = GetScoreDocAfter(_searchAfter);
 
                     // We want to only collect only the actual number of hits we want to take after the last document. We don't need to collect all previous/next docs.
                     numHits = _options.Take >= 1 ? _options.Take : QueryOptions.DefaultMaxResults;

--- a/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchExecutor.cs
@@ -27,14 +27,14 @@ namespace Examine.Lucene.Search
         private readonly ISearchContext _searchContext;
         private readonly Query _luceneQuery;
         private readonly ISet<string>? _fieldsToLoad;
-        private readonly IEnumerable<IFacetField>? _facetFields;
+        private readonly LuceneFacetSelectionOptions _facetFieldsSelectionOptions;
         private readonly FacetsConfig? _facetsConfig;
         private readonly LuceneDrillDownQueryDrillSideways? _drillDownQueryDrillSideways;
         private readonly SearchAfterOptions? _searchAfter;
         private int? _maxDoc;
 
         internal LuceneSearchExecutor(QueryOptions? options, Query query, IEnumerable<SortField> sortField, ISearchContext searchContext,
-            ISet<string>? fieldsToLoad, IEnumerable<IFacetField>? facetFields, FacetsConfig? facetsConfig, SearchAfterOptions? searchAfter,
+            ISet<string>? fieldsToLoad, LuceneFacetSelectionOptions facetFieldsSelectionOptions, FacetsConfig? facetsConfig, SearchAfterOptions? searchAfter,
             LuceneDrillDownQueryDrillSideways? drillDownQueryDrillSideways)
         {
             _options = options ?? QueryOptions.Default;
@@ -43,7 +43,7 @@ namespace Examine.Lucene.Search
             _fieldsToLoad = fieldsToLoad;
             _sortField = sortField ?? throw new ArgumentNullException(nameof(sortField));
             _searchContext = searchContext ?? throw new ArgumentNullException(nameof(searchContext));
-            _facetFields = facetFields;
+            _facetFieldsSelectionOptions = facetFieldsSelectionOptions;
             _facetsConfig = facetsConfig;
             _drillDownQueryDrillSideways = drillDownQueryDrillSideways;
             _searchAfter = _luceneQueryOptions?.SearchAfter ?? searchAfter;
@@ -142,11 +142,14 @@ namespace Examine.Lucene.Search
                     topDocsCollector = TopScoreDocCollector.Create(numHits, scoreDocAfter, true);
                 }
                 FacetsCollector? facetsCollector = null;
-                if (_facetFields != null && _facetFields.Any() && _luceneQueryOptions != null && _luceneQueryOptions.FacetRandomSampling != null)
+                if (_facetFieldsSelectionOptions != null &&
+                    (_facetFieldsSelectionOptions.FacetFields.Any() || _facetFieldsSelectionOptions.FacetAllFieldsWithHits)
+                    && _luceneQueryOptions != null && _luceneQueryOptions.FacetRandomSampling != null)
                 {
                     var facetsCollectors = new RandomSamplingFacetsCollector(_luceneQueryOptions.FacetRandomSampling.SampleSize, _luceneQueryOptions.FacetRandomSampling.Seed);
                 }
-                else if (_facetFields != null && _facetFields.Any())
+                else if (_facetFieldsSelectionOptions != null &&
+                    (_facetFieldsSelectionOptions.FacetFields.Any() || _facetFieldsSelectionOptions.FacetAllFieldsWithHits))
                 {
                     facetsCollector = new FacetsCollector();
                 }
@@ -328,17 +331,30 @@ namespace Examine.Lucene.Search
         {
 
             var facets = new Dictionary<string, IFacetResult>(StringComparer.InvariantCultureIgnoreCase);
-            if (facetExtractionContext == null)
+            if (facetExtractionContext == null || _facetFieldsSelectionOptions is null)
+            {
+                return facets;
+            }
+            if (_facetFieldsSelectionOptions.FacetAllFieldsWithHits)
+            {
+                // May not be the only Facets implementation that could be supported
+                var facetCounts = facetExtractionContext.DrillSidewaysResultFacets;
+                var luceneFacetResults = facetCounts.GetAllDims(_facetFieldsSelectionOptions.FacetAllFieldsWithHitsMaxCount);
+                Dictionary<string, IFacetResult> results = new Dictionary<string, IFacetResult>();
+                foreach (var luceneFacetResult in luceneFacetResults)
+                {
+                    var facetAllResults = new KeyValuePair<string, IFacetResult>(luceneFacetResult.Dim, new Examine.Search.FacetResult(luceneFacetResult.LabelValues.Select(labelValue => new FacetValue(labelValue.Label, labelValue.Value) as IFacetValue)));
+                    results.Add(facetAllResults.Key, facetAllResults.Value);
+                }
+                return results;
+            }
+
+            if (!_facetFieldsSelectionOptions.FacetFields.Any())
             {
                 return facets;
             }
 
-            if (_facetFields is null || !_facetFields.Any())
-            {
-                return facets;
-            }
-
-            var facetFields = _facetFields.OrderBy(field => field.FacetField);
+            var facetFields = _facetFieldsSelectionOptions.FacetFields.OrderBy(field => field.FacetField);
 
             foreach (var field in facetFields)
             {

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -231,7 +231,7 @@ namespace Examine.Lucene.Search
 
         internal LuceneBooleanOperationBase DrillDownQueryInternal(Func<INestedQuery, INestedBooleanOperation>? baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways>? drillSideways, BooleanOperation defaultOp, Occur occurance)
         {
-            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
+            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions(_facetsConfig);
             dimensions(luceneDrillDownQueryDimensions);
 
             if (drillSideways is not null)

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -251,23 +251,10 @@ namespace Examine.Lucene.Search
                 bo.OpBaseQuery(buildQuery, baseQuery, occurance.ToBooleanOperation(), defaultOp);
                 return bo;
             }
-            Query.Add(new LateBoundQuery(() =>
-            {
-                //Strangely we need an inner and outer query. If we don't do this then the lucene syntax returned is incorrect 
-                //since it doesn't wrap in parenthesis properly. I'm unsure if this is a lucene issue (assume so) since that is what
-                //is producing the resulting lucene string syntax. It might not be needed internally within Lucene since it's an object
-                //so it might be the ToString() that is the issue.
-                var outer = new BooleanQuery();
-                var inner = new BooleanQuery();
 
-                var drillDownQuery = new DrillDownQuery(this._facetsConfig);
-                luceneDrillDownQueryDimensions.Apply(drillDownQuery);
-
-                outer.Add(drillDownQuery, Occur.SHOULD);
-
-                return outer;
-            }), occurance);
-
+            var drillDownQuery = new DrillDownQuery(this._facetsConfig);
+            luceneDrillDownQueryDimensions.Apply(drillDownQuery);
+            Query.Add(drillDownQuery, occurance);
             return CreateOp();
         }
 

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -132,11 +132,11 @@ namespace Examine.Lucene.Search
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
         /// <inheritdoc/>
-        public override IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways) =>
+        public override IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways) =>
             DrillDownQueryInternal(dimensions, drillSideways, Occurrence);
 
         /// <inheritdoc/>
-        public override IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or) =>
+        public override IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or) =>
             DrillDownQueryInternal(inner, dimensions, drillSideways, defaultOp, Occurrence);
 
         internal LuceneBooleanOperationBase ManagedQueryInternal(string query, string[]? fields, Occur occurance)

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -19,7 +19,7 @@ namespace Examine.Lucene.Search
         private readonly ISearchContext _searchContext;
         private readonly FacetsConfig? _facetsConfig;
         private ISet<string>? _fieldsToLoad = null;
-        private readonly IList<IFacetField> _facetFields = new List<IFacetField>();
+        private readonly LuceneFacetSelectionOptions _facetSelectionOptions = new LuceneFacetSelectionOptions();
         private SearchAfterOptions? _searchAfter;
         private LuceneDrillDownQueryDrillSideways? _drillDownQueryDrillSideways;
 
@@ -300,7 +300,7 @@ namespace Examine.Lucene.Search
                 }
             }
 
-            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, _facetFields, _facetsConfig, _searchAfter, _drillDownQueryDrillSideways);
+            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, _facetSelectionOptions, _facetsConfig, _searchAfter, _drillDownQueryDrillSideways);
 
             var pagesResults = executor.Execute();
 
@@ -405,7 +405,7 @@ namespace Examine.Lucene.Search
 
             facetConfiguration?.Invoke(new FacetQueryField(facet));
 
-            _facetFields.Add(facet);
+            _facetSelectionOptions.FacetFields.Add(facet);
 
             return new LuceneFacetOperation(this);
         }
@@ -417,7 +417,7 @@ namespace Examine.Lucene.Search
             var valueType = _searchContext.GetFieldValueType(field) as IIndexFacetValueType;
             var facet = new FacetDoubleField(field, doubleRanges, GetFacetField(field), isTaxonomyIndexed: valueType?.IsTaxonomyFaceted ?? false);
 
-            _facetFields.Add(facet);
+            _facetSelectionOptions.FacetFields.Add(facet);
 
             return new LuceneFacetOperation(this);
         }
@@ -429,7 +429,7 @@ namespace Examine.Lucene.Search
             var valueType = _searchContext.GetFieldValueType(field) as IIndexFacetValueType;
             var facet = new FacetFloatField(field, floatRanges, GetFacetField(field), isTaxonomyIndexed: valueType?.IsTaxonomyFaceted ?? false);
 
-            _facetFields.Add(facet);
+            _facetSelectionOptions.FacetFields.Add(facet);
 
             return new LuceneFacetOperation(this);
         }
@@ -441,8 +441,15 @@ namespace Examine.Lucene.Search
             var valueType = _searchContext.GetFieldValueType(field) as IIndexFacetValueType;
             var facet = new FacetLongField(field, longRanges, GetFacetField(field), isTaxonomyIndexed: valueType?.IsTaxonomyFaceted ?? false);
 
-            _facetFields.Add(facet);
+            _facetSelectionOptions.FacetFields.Add(facet);
 
+            return new LuceneFacetOperation(this);
+        }
+
+        internal IFacetOperations FacetAllDimensionsInternal(int maxCount)
+        {
+            _facetSelectionOptions.FacetAllFieldsWithHits = true;
+            _facetSelectionOptions.FacetAllFieldsWithHitsMaxCount = maxCount;
             return new LuceneFacetOperation(this);
         }
 

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -249,23 +249,10 @@ namespace Examine.Lucene.Search
                 bo.OpBaseQuery(buildQuery, baseQuery, occurance.ToBooleanOperation(), defaultOp);
                 return bo;
             }
-            Query.Add(new LateBoundQuery(() =>
-            {
-                //Strangely we need an inner and outer query. If we don't do this then the lucene syntax returned is incorrect 
-                //since it doesn't wrap in parenthesis properly. I'm unsure if this is a lucene issue (assume so) since that is what
-                //is producing the resulting lucene string syntax. It might not be needed internally within Lucene since it's an object
-                //so it might be the ToString() that is the issue.
-                var outer = new BooleanQuery();
-                var inner = new BooleanQuery();
 
-                var drillDownQuery = new DrillDownQuery(this._facetsConfig);
-                luceneDrillDownQueryDimensions.Apply(drillDownQuery);
-
-                outer.Add(drillDownQuery, Occur.SHOULD);
-
-                return outer;
-            }), occurance);
-
+            var drillDownQuery = new DrillDownQuery(this._facetsConfig);
+            luceneDrillDownQueryDimensions.Apply(drillDownQuery);
+            Query.Add(drillDownQuery, occurance);
             return CreateOp();
         }
 

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -21,6 +21,7 @@ namespace Examine.Lucene.Search
         private ISet<string>? _fieldsToLoad = null;
         private readonly IList<IFacetField> _facetFields = new List<IFacetField>();
         private SearchAfterOptions? _searchAfter;
+        private LuceneDrillDownQueryDrillSideways? _drillDownQueryDrillSideways;
 
         /// <inheritdoc/>
         [Obsolete("To be removed in Examine V5")]
@@ -131,13 +132,10 @@ namespace Examine.Lucene.Search
         protected override INestedBooleanOperation RangeQueryNested<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true)
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
-        /// <inheritdoc/>
-        public override IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways) =>
-            DrillDownQueryInternal(dimensions, drillSideways, Occurrence);
 
         /// <inheritdoc/>
-        public override IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or) =>
-            DrillDownQueryInternal(inner, dimensions, drillSideways, defaultOp, Occurrence);
+        public override IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Func<INestedQuery, INestedBooleanOperation>? baseQuery = null, Action<IDrillSideways>? drillSideways = null, BooleanOperation defaultOp = BooleanOperation.Or) =>
+            DrillDownQueryInternal(baseQuery, dimensions, drillSideways, defaultOp, Occurrence);
 
         internal LuceneBooleanOperationBase ManagedQueryInternal(string query, string[]? fields, Occur occurance)
         {
@@ -229,8 +227,28 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
-        internal LuceneBooleanOperationBase DrillDownQueryInternal(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, Occur occurance)
+        internal LuceneBooleanOperationBase DrillDownQueryInternal(Func<INestedQuery, INestedBooleanOperation>? baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways>? drillSideways, BooleanOperation defaultOp, Occur occurance)
         {
+            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
+            dimensions(luceneDrillDownQueryDimensions);
+
+            if (drillSideways is not null)
+            {
+                _drillDownQueryDrillSideways = new LuceneDrillDownQueryDrillSideways();
+                drillSideways(_drillDownQueryDrillSideways);
+            }
+            if (baseQuery != null)
+            {
+                Func<Query, Query> buildQuery = (baseQuery) =>
+                {
+                    var drillDownQuery = new DrillDownQuery(_facetsConfig, baseQuery);
+                    luceneDrillDownQueryDimensions.Apply(drillDownQuery);
+                    return drillDownQuery;
+                };
+                var bo = new LuceneBooleanOperation(this);
+                bo.OpBaseQuery(buildQuery, baseQuery, occurance.ToBooleanOperation(), defaultOp);
+                return bo;
+            }
             Query.Add(new LateBoundQuery(() =>
             {
                 //Strangely we need an inner and outer query. If we don't do this then the lucene syntax returned is incorrect 
@@ -240,15 +258,8 @@ namespace Examine.Lucene.Search
                 var outer = new BooleanQuery();
                 var inner = new BooleanQuery();
 
-                var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
-                dimensions(luceneDrillDownQueryDimensions);
-
-                var luceneDrillDownQueryDrillSideways = new LuceneDrillDownQueryDrillSideways();
-                drillSideways(luceneDrillDownQueryDrillSideways);
-
                 var drillDownQuery = new DrillDownQuery(this._facetsConfig);
                 luceneDrillDownQueryDimensions.Apply(drillDownQuery);
-
 
                 outer.Add(drillDownQuery, Occur.SHOULD);
 
@@ -256,25 +267,6 @@ namespace Examine.Lucene.Search
             }), occurance);
 
             return CreateOp();
-        }
-
-        internal LuceneBooleanOperationBase DrillDownQueryInternal(Func<INestedQuery, INestedBooleanOperation> baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp, Occur occurance)
-        {
-            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
-            dimensions(luceneDrillDownQueryDimensions);
-
-            var luceneDrillDownQueryDrillSideways = new LuceneDrillDownQueryDrillSideways();
-            drillSideways(luceneDrillDownQueryDrillSideways);
-
-            Func<Query, Query> buildQuery = (baseQuery) =>
-            {
-                var drillDownQuery = new DrillDownQuery(_facetsConfig, baseQuery);
-                luceneDrillDownQueryDimensions.Apply(drillDownQuery);
-                return drillDownQuery;
-            };
-            var bo = new LuceneBooleanOperation(this);
-            bo.OpBaseQuery(buildQuery, baseQuery, occurance.ToBooleanOperation(), defaultOp);
-            return bo;
         }
 
         /// <summary>
@@ -321,7 +313,7 @@ namespace Examine.Lucene.Search
                 }
             }
 
-            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, _facetFields, _facetsConfig, _searchAfter);
+            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, _facetFields, _facetsConfig, _searchAfter, _drillDownQueryDrillSideways);
 
             var pagesResults = executor.Execute();
 
@@ -506,6 +498,5 @@ namespace Examine.Lucene.Search
             }
             return false;
         }
-
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -130,6 +130,10 @@ namespace Examine.Lucene.Search
         protected override INestedBooleanOperation RangeQueryNested<T>(string[] fields, T? min, T? max, bool minInclusive = true, bool maxInclusive = true)
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
+        /// <inheritdoc/>
+        public override IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions) =>
+            DrillDownQueryInternal(dimensions,Occurrence);
+
         internal LuceneBooleanOperationBase ManagedQueryInternal(string query, string[]? fields, Occur occurance)
         {
             Query.Add(new LateBoundQuery(() =>
@@ -213,6 +217,32 @@ namespace Examine.Lucene.Search
                 }
 
                 outer.Add(inner, Occur.SHOULD);
+
+                return outer;
+            }), occurance);
+
+            return CreateOp();
+        }
+
+        internal LuceneBooleanOperationBase DrillDownQueryInternal(Action<IDrillDownQueryDimensions> dimensions, Occur occurance)
+        {
+            Query.Add(new LateBoundQuery(() =>
+            {
+                //Strangely we need an inner and outer query. If we don't do this then the lucene syntax returned is incorrect 
+                //since it doesn't wrap in parenthesis properly. I'm unsure if this is a lucene issue (assume so) since that is what
+                //is producing the resulting lucene string syntax. It might not be needed internally within Lucene since it's an object
+                //so it might be the ToString() that is the issue.
+                var outer = new BooleanQuery();
+                var inner = new BooleanQuery();
+
+                LuceneDrillDownQueryDimensions luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
+                dimensions(luceneDrillDownQueryDimensions);
+
+                DrillDownQuery drillDownQuery = new DrillDownQuery(this._facetsConfig);
+                luceneDrillDownQueryDimensions.Apply(drillDownQuery);
+              
+
+                outer.Add(drillDownQuery, Occur.SHOULD);
 
                 return outer;
             }), occurance);
@@ -443,5 +473,6 @@ namespace Examine.Lucene.Search
             }
             return false;
         }
+
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -229,7 +229,7 @@ namespace Examine.Lucene.Search
 
         internal LuceneBooleanOperationBase DrillDownQueryInternal(Func<INestedQuery, INestedBooleanOperation>? baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways>? drillSideways, BooleanOperation defaultOp, Occur occurance)
         {
-            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
+            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions(_facetsConfig);
             dimensions(luceneDrillDownQueryDimensions);
 
             if (drillSideways is not null)

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -229,7 +229,7 @@ namespace Examine.Lucene.Search
 
         internal LuceneBooleanOperationBase DrillDownQueryInternal(Func<INestedQuery, INestedBooleanOperation>? baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways>? drillSideways, BooleanOperation defaultOp, Occur occurance)
         {
-            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions(_facetsConfig);
+            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
             dimensions(luceneDrillDownQueryDimensions);
 
             if (drillSideways is not null)

--- a/src/Examine.Lucene/Search/LuceneSearchQuery.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQuery.cs
@@ -20,6 +20,7 @@ namespace Examine.Lucene.Search
         private readonly FacetsConfig? _facetsConfig;
         private ISet<string>? _fieldsToLoad = null;
         private readonly IList<IFacetField> _facetFields = new List<IFacetField>();
+        private SearchAfterOptions? _searchAfter;
 
         /// <inheritdoc/>
         [Obsolete("To be removed in Examine V5")]
@@ -36,7 +37,7 @@ namespace Examine.Lucene.Search
             ISearchContext searchContext,
             string? category, Analyzer analyzer, LuceneSearchOptions searchOptions, BooleanOperation occurance, FacetsConfig facetsConfig)
             : base(CreateQueryParser(searchContext, analyzer, searchOptions), category, searchOptions, occurance)
-        {   
+        {
             _searchContext = searchContext;
             _facetsConfig = facetsConfig;
         }
@@ -131,8 +132,12 @@ namespace Examine.Lucene.Search
             => RangeQueryInternal(fields, min, max, minInclusive, maxInclusive, Occurrence);
 
         /// <inheritdoc/>
-        public override IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions) =>
-            DrillDownQueryInternal(dimensions,Occurrence);
+        public override IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways) =>
+            DrillDownQueryInternal(dimensions, drillSideways, Occurrence);
+
+        /// <inheritdoc/>
+        public override IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or) =>
+            DrillDownQueryInternal(inner, dimensions, drillSideways, defaultOp, Occurrence);
 
         internal LuceneBooleanOperationBase ManagedQueryInternal(string query, string[]? fields, Occur occurance)
         {
@@ -224,7 +229,7 @@ namespace Examine.Lucene.Search
             return CreateOp();
         }
 
-        internal LuceneBooleanOperationBase DrillDownQueryInternal(Action<IDrillDownQueryDimensions> dimensions, Occur occurance)
+        internal LuceneBooleanOperationBase DrillDownQueryInternal(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, Occur occurance)
         {
             Query.Add(new LateBoundQuery(() =>
             {
@@ -235,12 +240,15 @@ namespace Examine.Lucene.Search
                 var outer = new BooleanQuery();
                 var inner = new BooleanQuery();
 
-                LuceneDrillDownQueryDimensions luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
+                var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
                 dimensions(luceneDrillDownQueryDimensions);
 
-                DrillDownQuery drillDownQuery = new DrillDownQuery(this._facetsConfig);
+                var luceneDrillDownQueryDrillSideways = new LuceneDrillDownQueryDrillSideways();
+                drillSideways(luceneDrillDownQueryDrillSideways);
+
+                var drillDownQuery = new DrillDownQuery(this._facetsConfig);
                 luceneDrillDownQueryDimensions.Apply(drillDownQuery);
-              
+
 
                 outer.Add(drillDownQuery, Occur.SHOULD);
 
@@ -249,6 +257,31 @@ namespace Examine.Lucene.Search
 
             return CreateOp();
         }
+
+        internal LuceneBooleanOperationBase DrillDownQueryInternal(Func<INestedQuery, INestedBooleanOperation> baseQuery, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp, Occur occurance)
+        {
+            var luceneDrillDownQueryDimensions = new LuceneDrillDownQueryDimensions();
+            dimensions(luceneDrillDownQueryDimensions);
+
+            var luceneDrillDownQueryDrillSideways = new LuceneDrillDownQueryDrillSideways();
+            drillSideways(luceneDrillDownQueryDrillSideways);
+
+            Func<Query, Query> buildQuery = (baseQuery) =>
+            {
+                var drillDownQuery = new DrillDownQuery(_facetsConfig, baseQuery);
+                luceneDrillDownQueryDimensions.Apply(drillDownQuery);
+                return drillDownQuery;
+            };
+            var bo = new LuceneBooleanOperation(this);
+            bo.OpBaseQuery(buildQuery, baseQuery, occurance.ToBooleanOperation(), defaultOp);
+            return bo;
+        }
+
+        /// <summary>
+        /// Set the SearchAfter to continue the search from a previous position
+        /// </summary>
+        /// <param name="searchAfter">Search After Options</param>
+        public virtual void SetSearchAfter(SearchAfter searchAfter) => _searchAfter = new SearchAfterOptions(searchAfter);
 
         /// <inheritdoc />
         public ISearchResults Execute(QueryOptions? options = null) => Search(options);
@@ -288,12 +321,12 @@ namespace Examine.Lucene.Search
                 }
             }
 
-            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, _facetFields, _facetsConfig);
+            var executor = new LuceneSearchExecutor(options, query, SortFields, _searchContext, _fieldsToLoad, _facetFields, _facetsConfig, _searchAfter);
 
             var pagesResults = executor.Execute();
 
             return pagesResults;
-        }        
+        }
 
         /// <summary>
         /// Internal operation for adding the ordered results
@@ -312,7 +345,7 @@ namespace Examine.Lucene.Search
             {
                 var fieldName = f.FieldName;
 
-                var defaultSort =  SortFieldType.STRING;
+                var defaultSort = SortFieldType.STRING;
 
                 switch (f.SortType)
                 {
@@ -336,7 +369,7 @@ namespace Examine.Lucene.Search
                         break;
                     case SortType.Double:
                         defaultSort = SortFieldType.DOUBLE;
-                        break;                   
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -436,7 +469,7 @@ namespace Examine.Lucene.Search
 
         private string GetFacetField(string field)
         {
-            if(_facetsConfig is null)
+            if (_facetsConfig is null)
             {
                 throw new InvalidOperationException("FacetsConfig not set. User a LuceneSearchQuery constructor with all parameters");
             }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -632,9 +632,6 @@ namespace Examine.Lucene.Search
         public override string ToString() => $"{{ Category: {Category}, LuceneQuery: {Query} }}";
 
         /// <inheritdoc/>
-        public abstract IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
-
-        /// <inheritdoc/>
-        public abstract IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
+        public abstract IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Func<INestedQuery, INestedBooleanOperation>? baseQuery = null, Action<IDrillSideways>? drillSideways = null, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Examine.Search;
-using Lucene.Net.Facet;
-using Lucene.Net.Facet.Range;
 using Lucene.Net.Index;
 using Lucene.Net.QueryParsers.Classic;
 using Lucene.Net.Search;
@@ -199,9 +196,6 @@ namespace Examine.Lucene.Search
 
             return GroupedNotInternal(fields.ToArray(), query);
         }
-
-        /// <inheritdoc/>
-        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions);
 
         #region INested
 
@@ -636,5 +630,11 @@ namespace Examine.Lucene.Search
         /// A <see cref="string"/> that represents this instance.
         /// </returns>
         public override string ToString() => $"{{ Category: {Category}, LuceneQuery: {Query} }}";
+
+        /// <inheritdoc/>
+        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
+
+        /// <inheritdoc/>
+        public abstract IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Examine.Search;
+using Lucene.Net.Facet;
 using Lucene.Net.Facet.Range;
 using Lucene.Net.Index;
 using Lucene.Net.QueryParsers.Classic;
@@ -198,6 +199,9 @@ namespace Examine.Lucene.Search
 
             return GroupedNotInternal(fields.ToArray(), query);
         }
+
+        /// <inheritdoc/>
+        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions);
 
         #region INested
 

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -632,9 +632,9 @@ namespace Examine.Lucene.Search
         public override string ToString() => $"{{ Category: {Category}, LuceneQuery: {Query} }}";
 
         /// <inheritdoc/>
-        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
+        public abstract IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
 
         /// <inheritdoc/>
-        public abstract IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
+        public abstract IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -538,9 +538,6 @@ namespace Examine.Lucene.Search
         public override string ToString() => $"{{ Category: {Category}, LuceneQuery: {Query} }}";
 
         /// <inheritdoc/>
-        public abstract IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
-
-        /// <inheritdoc/>
-        public abstract IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
+        public abstract IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Func<INestedQuery, INestedBooleanOperation>? baseQuery = null, Action<IDrillSideways>? drillSideways = null, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Examine.Search;
-using Lucene.Net.Facet;
-using Lucene.Net.Facet.Range;
 using Lucene.Net.Index;
 using Lucene.Net.QueryParsers.Classic;
 using Lucene.Net.Search;
@@ -198,9 +195,6 @@ namespace Examine.Lucene.Search
 
             return GroupedNotInternal(fields.ToArray(), query);
         }
-
-        /// <inheritdoc/>
-        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions);
 
         #region INested
 
@@ -542,5 +536,11 @@ namespace Examine.Lucene.Search
         /// A <see cref="string"/> that represents this instance.
         /// </returns>
         public override string ToString() => $"{{ Category: {Category}, LuceneQuery: {Query} }}";
+
+        /// <inheritdoc/>
+        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
+
+        /// <inheritdoc/>
+        public abstract IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -538,9 +538,9 @@ namespace Examine.Lucene.Search
         public override string ToString() => $"{{ Category: {Category}, LuceneQuery: {Query} }}";
 
         /// <inheritdoc/>
-        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
+        public abstract IOrdering DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways);
 
         /// <inheritdoc/>
-        public abstract IBooleanOperation DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
+        public abstract IOrdering DrillDownQuery(Func<INestedQuery, INestedBooleanOperation> inner, Action<IDrillDownQueryDimensions> dimensions, Action<IDrillSideways> drillSideways, BooleanOperation defaultOp = BooleanOperation.Or);
     }
 }

--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Examine.Search;
+using Lucene.Net.Facet;
 using Lucene.Net.Facet.Range;
 using Lucene.Net.Index;
 using Lucene.Net.QueryParsers.Classic;
@@ -197,6 +198,9 @@ namespace Examine.Lucene.Search
 
             return GroupedNotInternal(fields.ToArray(), query);
         }
+
+        /// <inheritdoc/>
+        public abstract IBooleanOperation DrillDownQuery(Action<IDrillDownQueryDimensions> dimensions);
 
         #region INested
 

--- a/src/Examine.Lucene/Search/SearchAfterOptions.cs
+++ b/src/Examine.Lucene/Search/SearchAfterOptions.cs
@@ -1,3 +1,6 @@
+using System;
+using Examine.Search;
+
 namespace Examine.Lucene.Search
 {
     /// <summary>
@@ -5,7 +8,6 @@ namespace Examine.Lucene.Search
     /// </summary>
     public class SearchAfterOptions
     {
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -19,6 +21,31 @@ namespace Examine.Lucene.Search
             DocumentScore = documentScore;
             Fields = fields;
             ShardIndex = shardIndex;
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="searchAfter">Search After</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public SearchAfterOptions(SearchAfter searchAfter)
+        {
+            if (searchAfter is null)
+            {
+                throw new ArgumentNullException(nameof(searchAfter));
+            }
+            if (string.IsNullOrWhiteSpace(searchAfter.Value))
+            {
+                throw new ArgumentException(nameof(searchAfter));
+            }
+            var searchAfterVals = searchAfter.Value.Split('|');
+            DocumentId = int.Parse(searchAfterVals[0]);
+            DocumentScore = int.Parse(searchAfterVals[1]);
+            if (!string.IsNullOrEmpty(searchAfterVals[2]))
+            {
+                ShardIndex = int.Parse(searchAfterVals[2]);
+            }
         }
 
         /// <summary>
@@ -42,5 +69,15 @@ namespace Examine.Lucene.Search
         /// Search fields. Should contain null or J2N.Int
         /// </summary>
         public object[]? Fields { get; }
+
+        /// <summary>
+        /// To Search After
+        /// </summary>
+        /// <returns></returns>
+        public SearchAfter ToSearchAfter()
+        {
+            var searchAfterSerialized = string.Join("|", DocumentId, DocumentScore, ShardIndex);
+            return new SearchAfter(searchAfterSerialized);
+        }
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5193,107 +5193,47 @@ namespace Examine.Test.Examine.Lucene.Search
         }
 
         [TestCase(FacetTestType.TaxonomyFacets)]
-        [TestCase(FacetTestType.SortedSetFacets)]
-        [TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
-        {
-            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
-            var facetConfigs = new FacetsConfig();
-            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
-
-            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
-            facetConfigs.SetHierarchical("publishDate", true);
-
-            using (var luceneDir = new RandomIdRAMDirectory())
-            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
-            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
-                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
-
-                ), facetsConfig: facetConfigs))
-            {
-                var items = new ValueSet[] {
-                    ValueSet.FromObject("1", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                     ValueSet.FromObject("2", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                      ValueSet.FromObject("3", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                       ValueSet.FromObject("4", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                        ValueSet.FromObject("5", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
-                };
-
-                indexer.IndexItems(items);
-
-                var taxonomySearcher = indexer.TaxonomySearcher;
-                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
-
-                //Arrange
-
-                var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                    dims =>
-                    {
-                        // Filter the nodePath to the 2010 category
-                        dims.AddDimension("publishDate", "2010", "10");
-                    },
-                    null,
-                    sideways =>
-                    {
-
-                    })
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate");
-                    }));
-
-                //Act
-
-                var results1 = sc.ExecuteWithLucene();
-
-                var facetResults1 = results1.GetFacet("publishDate");
-
-                Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(1, facetResults1.Count());
-            }
-        }
-
-
-        [TestCase(FacetTestType.TaxonomyFacets)]
-        [TestCase(FacetTestType.SortedSetFacets)]
-        [TestCase(FacetTestType.NoFacets)]
+        //[TestCase(FacetTestType.SortedSetFacets)]
+        //[TestCase(FacetTestType.NoFacets)]
         public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();
             facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
-
-            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
+            //facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate"); //Not working
             facetConfigs.SetHierarchical("publishDate", true);
 
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
             using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
                 new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("Author", FieldDefinitionTypes.FacetTaxonomyFullText),
                 new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
                 new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
 
                 ), facetsConfig: facetConfigs))
             {
                 var items = new ValueSet[] {
-                    ValueSet.FromObject("1", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    ValueSet.FromObject(
+                        "1",
+                        "content",
+                        new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }),
+                            nodeName = "umbraco",
+                            Author = "Bob",
+                            writerName = "administrator",
+                            taxonomynodeName = "umbraco" }),
                      ValueSet.FromObject("2", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ),
+                        nodeName = "umbraco", Author = "Lisa", writerName = "administrator", taxonomynodeName = "umbraco" }),
                       ValueSet.FromObject("3", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ),
+                        nodeName = "umbraco", Author = "Lisa", writerName = "administrator", taxonomynodeName = "umbraco" }),
                        ValueSet.FromObject("4", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}),
+                        nodeName = "umbraco", Author = "Susan", writerName = "administrator", taxonomynodeName = "umbraco" }),
                         ValueSet.FromObject("5", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ),
+                        nodeName = "umbraco", Author = "Frank", writerName = "administrator", taxonomynodeName = "umbraco" })
                 };
 
                 indexer.IndexItems(items);
@@ -5301,110 +5241,38 @@ namespace Examine.Test.Examine.Lucene.Search
                 var taxonomySearcher = indexer.TaxonomySearcher;
                 var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
 
-                //Arrange
 
+                //Act
+                //  case: drill-down on a single field; in this
+                // case the drill-sideways + drill-down counts ==
+                // drill-down of just the query: 
                 var sc = taxonomySearcher.CreateQuery("content")
                     .DrillDownQuery(
                      dims =>
                      {
-                         // Filter the nodePath to the 2010 category
-                         dims.AddDimension("publishDate", "2010", "10");
+                         dims.AddDimension("Author", "Lisa");
                      },
-                     baseQuery =>
-                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
+                     null
                     ,
                     sideways =>
                     {
-
+                        sideways.SetTopN(10);
                     },
                     BooleanOperation.Or)
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
                         facets.FacetString("publishDate");
                     }));
-
-                //Act
-
                 var results1 = sc.ExecuteWithLucene();
 
                 var facetResults1 = results1.GetFacet("publishDate");
-
+                // Publish Date is only drill-down, and Lisa published
+                // one in 2012 and one in 2010:
                 Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(1, facetResults1.Count());
+                Assert.AreEqual(2, facetResults1.Count());
+
+
             }
         }
-
-        [TestCase(FacetTestType.TaxonomyFacets)]
-        [TestCase(FacetTestType.SortedSetFacets)]
-        [TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
-        {
-            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
-            var facetConfigs = new FacetsConfig();
-            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
-
-            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
-            facetConfigs.SetHierarchical("publishDate", true);
-
-            using (var luceneDir = new RandomIdRAMDirectory())
-            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
-            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
-                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
-
-                ), facetsConfig: facetConfigs))
-            {
-                var items = new ValueSet[] {
-                    ValueSet.FromObject("1", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                     ValueSet.FromObject("2", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                      ValueSet.FromObject("3", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                       ValueSet.FromObject("4", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                        ValueSet.FromObject("5", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
-                };
-
-                indexer.IndexItems(items);
-
-                var taxonomySearcher = indexer.TaxonomySearcher;
-                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
-
-                //Arrange
-
-                var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                    dims =>
-                    {
-                        // Filter the nodePath to the 2010 category
-                        dims.AddDimension("publishDate", "2010", "10");
-                    },
-                    baseQuery =>
-                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
-                    ,
-                    sideways =>
-                    {
-                        sideways.SetTopN(20);
-                    },
-                    BooleanOperation.Or)
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate");
-                    }));
-
-                //Act
-
-                var results1 = sc.ExecuteWithLucene();
-
-                var facetResults1 = results1.GetFacet("publishDate");
-
-                Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(1, facetResults1.Count());
-            }
-        }
-
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5235,8 +5235,83 @@ namespace Examine.Test.Examine.Lucene.Search
                     .DrillDownQuery(dims =>
                     {
                         // Filter the nodePath to the 2010 category
-                        dims.AddDimension("publishDate", "2010");
+                        dims.AddDimension("publishDate", "2010", "10");
+                    },
+                    sideways =>
+                    {
+
                     })
+                    .WithFacets((Action<IFacetOperations>)(facets =>
+                    {
+                        facets.FacetString("publishDate");
+                    }));
+
+                //Act
+
+                var results1 = sc.ExecuteWithLucene();
+
+                var facetResults1 = results1.GetFacet("publishDate");
+
+                Assert.AreEqual(2, results1.Count());
+                Assert.AreEqual(1, facetResults1.Count());
+            }
+        }
+
+
+        [Test]
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            var facetConfigs = new FacetsConfig();
+            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
+
+            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
+            facetConfigs.SetHierarchical("publishDate", true);
+
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
+                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
+
+                ), facetsConfig: facetConfigs))
+            {
+                var items = new ValueSet[] {
+                    ValueSet.FromObject("1", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                     ValueSet.FromObject("2", "content",
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                      ValueSet.FromObject("3", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                       ValueSet.FromObject("4", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                        ValueSet.FromObject("5", "content",
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                };
+
+                indexer.IndexItems(items);
+
+                var taxonomySearcher = indexer.TaxonomySearcher;
+                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
+
+                //Arrange
+
+                var sc = taxonomySearcher.CreateQuery("content")
+                    .DrillDownQuery(
+                    baseQuery =>
+                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
+                    ,
+                    dims =>
+                    {
+                        // Filter the nodePath to the 2010 category
+                        dims.AddDimension("publishDate", "2010", "10");
+                    },
+                    sideways =>
+                    {
+
+                    },
+                    BooleanOperation.Or)
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
                         facets.FacetString("publishDate");

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5192,6 +5192,8 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
+
+        [TestCase()]
         public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
@@ -5240,178 +5242,183 @@ namespace Examine.Test.Examine.Lucene.Search
 
 
                 //Act
-                //  case: drill-down on a single field; in this
-                // case the drill-sideways + drill-down counts ==
-                // drill-down of just the query: 
-                var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                     dims =>
-                     {
-                         dims.AddDimension("Author", "Lisa");
-                     },
-                     null
-                    ,
-                    sideways =>
-                    {
-                        sideways.SetTopN(10);
-                    },
-                    BooleanOperation.Or)
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate", x => x.MaxCount(10));
-                        facets.FacetString("Author", x => x.MaxCount(10));
-                    }));
-                var results1 = sc.ExecuteWithLucene();
-
-                Assert.AreEqual(2, results1.Count());
-
-                var facetResults1PublishDate = results1.GetFacet("publishDate");
-                // Publish Date is only drill-down, and Lisa published
-                // one in 2012 and one in 2010:
-                Assert.AreEqual(2, facetResults1PublishDate.Count());
-
-                // Author is drill-sideways + drill-down: Lisa
-                // (drill-down) published twice, and Frank/Susan/Bob
-                // published once:
-                var facetResults1Author = results1.GetFacet("Author");
-                Assert.AreEqual(4, facetResults1Author.Count());
-
-                // Another simple case: drill-down on single fields
-                // but OR of two values
-                //Act
-                //  case: drill-down on a single field; in this
-                // case the drill-sideways + drill-down counts ==
-                // drill-down of just the query: 
-                var sc2 = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                     dims =>
-                     {
-                         dims.AddDimension("Author", "Lisa");
-                         dims.AddDimension("Author", "Bob");
-                     },
-                     null
-                    ,
-                    sideways =>
-                    {
-                        sideways.SetTopN(10);
-                    },
-                    BooleanOperation.Or)
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate", x => x.MaxCount(10));
-                        facets.FacetString("Author", x => x.MaxCount(10));
-                    }));
-                var results2 = sc2.ExecuteWithLucene();
-                Assert.AreEqual(3, results2.Count());
-
-                // Publish Date is only drill-down: Lisa and Bob
-                // (drill-down) published twice in 2010 and once in 2012:
-                var facetResults2PublishDate = results2.GetFacet("publishDate");
-                Assert.AreEqual(2, facetResults2PublishDate.Count());
-
-                // Author is drill-sideways + drill-down: Lisa
-                // (drill-down) published twice, and Frank/Susan/Bob
-                // published once:
-                var facetResults2Author = results2.GetFacet("Author");
-                Assert.AreEqual(4, facetResults2Author.Count());
-
-
-                // Publish Date is only drill-down: Lisa and Bob
-                // (drill-down) published twice in 2010 and once in 2012:
-                var sc3 = taxonomySearcher.CreateQuery("content")
-                   .DrillDownQuery(
-                    dims =>
-                    {
-                        dims.AddDimension("Author", "Lisa");
-                        dims.AddDimension("Author", "Bob");
-                    },
-                    null
-                   ,
-                   sideways =>
-                   {
-                       sideways.SetTopN(10);
-                   },
-                   BooleanOperation.Or)
-                   .WithFacets((Action<IFacetOperations>)(facets =>
-                   {
-                       facets.FacetAllDimensions(10);
-                   }));
-                var results3 = sc3.ExecuteWithLucene();
-                // Author is drill-sideways + drill-down: Lisa
-                // (drill-down) published twice, and Frank/Susan/Bob
-                // published once:
-                var facetResults3All = results3.GetFacets();
-                Assert.AreEqual(3, facetResults3All.Count());
-
-                // More interesting case: drill-down on two fields
-                var sc4 = taxonomySearcher.CreateQuery("content")
-                   .DrillDownQuery(
-                    dims =>
-                    {
-                        dims.AddDimension("Author", "Lisa");
-                        dims.AddDimension("publishDate", "2010");
-                    },
-                    null
-                   ,
-                   sideways =>
-                   {
-                       sideways.SetTopN(10);
-                   },
-                   BooleanOperation.Or)
-                   .WithFacets((Action<IFacetOperations>)(facets =>
-                   {
-                       facets.FacetString("publishDate", x => x.MaxCount(10));
-                       facets.FacetString("Author", x => x.MaxCount(10));
-                   }));
-                var results4 = sc4.ExecuteWithLucene();
-                Assert.AreEqual(1, results4.Count());
-
-                // Publish Date is drill-sideways + drill-down: Lisa
-                // (drill-down) published once in 2010 and once in 2012:
-                var facetResults4PublishDate = results4.GetFacet("publishDate");
-                Assert.AreEqual(2, facetResults4PublishDate.Count());
-
-                // Author is drill-sideways + drill-down:
-                // only Lisa & Bob published (once each) in 2010:
-                var facetResults4Author = results4.GetFacet("Author");
-                Assert.AreEqual(2, facetResults4Author.Count());
-
-
-                // Even more interesting case: drill down on two fields,
-                // but one of them is OR
-                var sc5 = taxonomySearcher.CreateQuery("content")
-                   .DrillDownQuery(
-                    dims =>
-                    {
-                        dims.AddDimension("Author", "Lisa");
-                        dims.AddDimension("publishDate", "2010");
-                        dims.AddDimension("Author", "Bob");
-                    },
-                    null
-                   ,
-                   sideways =>
-                   {
-                       sideways.SetTopN(10);
-                   },
-                   BooleanOperation.Or)
-                   .WithFacets((Action<IFacetOperations>)(facets =>
-                   {
-                       facets.FacetString("publishDate", x => x.MaxCount(10));
-                       facets.FacetString("Author", x => x.MaxCount(10));
-                   }));
-                var results5 = sc5.ExecuteWithLucene();
-                Assert.AreEqual(2, results5.Count());
-
-                // Publish Date is both drill-sideways + drill-down:
-                // Lisa or Bob published twice in 2010 and once in 2012:
-                var facetResults5PublishDate = results5.GetFacet("publishDate");
-                Assert.AreEqual(2, facetResults5PublishDate.Count());
-
-                // Author is drill-sideways + drill-down:
-                // only Lisa & Bob published (once each) in 2010:
-                var facetResults5Author = results5.GetFacet("Author");
-                Assert.AreEqual(2, facetResults5Author.Count());
+                BasicDrillSidewaysTests(taxonomySearcher);
             }
+        }
+
+        private static void BasicDrillSidewaysTests(ISearcher taxonomySearcher)
+        {
+            //  case: drill-down on a single field; in this
+            // case the drill-sideways + drill-down counts ==
+            // drill-down of just the query: 
+            var sc = taxonomySearcher.CreateQuery("content")
+                .DrillDownQuery(
+                 dims =>
+                 {
+                     dims.AddDimension("Author", "Lisa");
+                 },
+                 null
+                ,
+                sideways =>
+                {
+                    sideways.SetTopN(10);
+                },
+                BooleanOperation.Or)
+                .WithFacets((Action<IFacetOperations>)(facets =>
+                {
+                    facets.FacetString("publishDate", x => x.MaxCount(10));
+                    facets.FacetString("Author", x => x.MaxCount(10));
+                }));
+            var results1 = sc.ExecuteWithLucene();
+
+            Assert.AreEqual(2, results1.Count());
+
+            var facetResults1PublishDate = results1.GetFacet("publishDate");
+            // Publish Date is only drill-down, and Lisa published
+            // one in 2012 and one in 2010:
+            Assert.AreEqual(2, facetResults1PublishDate.Count());
+
+            // Author is drill-sideways + drill-down: Lisa
+            // (drill-down) published twice, and Frank/Susan/Bob
+            // published once:
+            var facetResults1Author = results1.GetFacet("Author");
+            Assert.AreEqual(4, facetResults1Author.Count());
+
+            // Another simple case: drill-down on single fields
+            // but OR of two values
+            //Act
+            //  case: drill-down on a single field; in this
+            // case the drill-sideways + drill-down counts ==
+            // drill-down of just the query: 
+            var sc2 = taxonomySearcher.CreateQuery("content")
+                .DrillDownQuery(
+                 dims =>
+                 {
+                     dims.AddDimension("Author", "Lisa");
+                     dims.AddDimension("Author", "Bob");
+                 },
+                 null
+                ,
+                sideways =>
+                {
+                    sideways.SetTopN(10);
+                },
+                BooleanOperation.Or)
+                .WithFacets((Action<IFacetOperations>)(facets =>
+                {
+                    facets.FacetString("publishDate", x => x.MaxCount(10));
+                    facets.FacetString("Author", x => x.MaxCount(10));
+                }));
+            var results2 = sc2.ExecuteWithLucene();
+            Assert.AreEqual(3, results2.Count());
+
+            // Publish Date is only drill-down: Lisa and Bob
+            // (drill-down) published twice in 2010 and once in 2012:
+            var facetResults2PublishDate = results2.GetFacet("publishDate");
+            Assert.AreEqual(2, facetResults2PublishDate.Count());
+
+            // Author is drill-sideways + drill-down: Lisa
+            // (drill-down) published twice, and Frank/Susan/Bob
+            // published once:
+            var facetResults2Author = results2.GetFacet("Author");
+            Assert.AreEqual(4, facetResults2Author.Count());
+
+
+            // Publish Date is only drill-down: Lisa and Bob
+            // (drill-down) published twice in 2010 and once in 2012:
+            var sc3 = taxonomySearcher.CreateQuery("content")
+               .DrillDownQuery(
+                dims =>
+                {
+                    dims.AddDimension("Author", "Lisa");
+                    dims.AddDimension("Author", "Bob");
+                },
+                null
+               ,
+               sideways =>
+               {
+                   sideways.SetTopN(10);
+               },
+               BooleanOperation.Or)
+               .WithFacets((Action<IFacetOperations>)(facets =>
+               {
+                   facets.FacetAllDimensions(10);
+               }));
+            var results3 = sc3.ExecuteWithLucene();
+            // Author is drill-sideways + drill-down: Lisa
+            // (drill-down) published twice, and Frank/Susan/Bob
+            // published once:
+            var facetResults3All = results3.GetFacets();
+            Assert.AreEqual(3, facetResults3All.Count());
+
+            // More interesting case: drill-down on two fields
+            var sc4 = taxonomySearcher.CreateQuery("content")
+               .DrillDownQuery(
+                dims =>
+                {
+                    dims.AddDimension("Author", "Lisa");
+                    dims.AddDimension("publishDate", "2010");
+                },
+                null
+               ,
+               sideways =>
+               {
+                   sideways.SetTopN(10);
+               },
+               BooleanOperation.Or)
+               .WithFacets((Action<IFacetOperations>)(facets =>
+               {
+                   facets.FacetString("publishDate", x => x.MaxCount(10));
+                   facets.FacetString("Author", x => x.MaxCount(10));
+               }));
+            var results4 = sc4.ExecuteWithLucene();
+            Assert.AreEqual(1, results4.Count());
+
+            // Publish Date is drill-sideways + drill-down: Lisa
+            // (drill-down) published once in 2010 and once in 2012:
+            var facetResults4PublishDate = results4.GetFacet("publishDate");
+            Assert.AreEqual(2, facetResults4PublishDate.Count());
+
+            // Author is drill-sideways + drill-down:
+            // only Lisa & Bob published (once each) in 2010:
+            var facetResults4Author = results4.GetFacet("Author");
+            Assert.AreEqual(2, facetResults4Author.Count());
+
+
+            // Even more interesting case: drill down on two fields,
+            // but one of them is OR
+            var sc5 = taxonomySearcher.CreateQuery("content")
+               .DrillDownQuery(
+                dims =>
+                {
+                    dims.AddDimension("Author", "Lisa");
+                    dims.AddDimension("publishDate", "2010");
+                    dims.AddDimension("Author", "Bob");
+                },
+                null
+               ,
+               sideways =>
+               {
+                   sideways.SetTopN(10);
+               },
+               BooleanOperation.Or)
+               .WithFacets((Action<IFacetOperations>)(facets =>
+               {
+                   facets.FacetString("publishDate", x => x.MaxCount(10));
+                   facets.FacetString("Author", x => x.MaxCount(10));
+               }));
+            var results5 = sc5.ExecuteWithLucene();
+            Assert.AreEqual(2, results5.Count());
+
+            // Publish Date is both drill-sideways + drill-down:
+            // Lisa or Bob published twice in 2010 and once in 2012:
+            var facetResults5PublishDate = results5.GetFacet("publishDate");
+            Assert.AreEqual(2, facetResults5PublishDate.Count());
+
+            // Author is drill-sideways + drill-down:
+            // only Lisa & Bob published (once each) in 2010:
+            var facetResults5Author = results5.GetFacet("Author");
+            Assert.AreEqual(2, facetResults5Author.Count());
         }
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5192,8 +5192,10 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
-        [Test]
-        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet()
+        [TestCase(FacetTestType.TaxonomyFacets)]
+        [TestCase(FacetTestType.SortedSetFacets)]
+        [TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();
@@ -5260,8 +5262,10 @@ namespace Examine.Test.Examine.Lucene.Search
         }
 
 
-        [Test]
-        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
+        [TestCase(FacetTestType.TaxonomyFacets)]
+        [TestCase(FacetTestType.SortedSetFacets)]
+        [TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();
@@ -5330,8 +5334,10 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
-        [Test]
-        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet()
+        [TestCase(FacetTestType.TaxonomyFacets)]
+        [TestCase(FacetTestType.SortedSetFacets)]
+        [TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5246,12 +5246,12 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
-        private static void BasicDrillSidewaysTests(ISearcher taxonomySearcher)
+        private static void BasicDrillSidewaysTests(ISearcher searcher)
         {
             //  case: drill-down on a single field; in this
             // case the drill-sideways + drill-down counts ==
             // drill-down of just the query: 
-            var sc = taxonomySearcher.CreateQuery("content")
+            var sc = searcher.CreateQuery("content")
                 .DrillDownQuery(
                  dims =>
                  {
@@ -5290,7 +5290,7 @@ namespace Examine.Test.Examine.Lucene.Search
             //  case: drill-down on a single field; in this
             // case the drill-sideways + drill-down counts ==
             // drill-down of just the query: 
-            var sc2 = taxonomySearcher.CreateQuery("content")
+            var sc2 = searcher.CreateQuery("content")
                 .DrillDownQuery(
                  dims =>
                  {
@@ -5326,7 +5326,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
             // Publish Date is only drill-down: Lisa and Bob
             // (drill-down) published twice in 2010 and once in 2012:
-            var sc3 = taxonomySearcher.CreateQuery("content")
+            var sc3 = searcher.CreateQuery("content")
                .DrillDownQuery(
                 dims =>
                 {
@@ -5352,7 +5352,7 @@ namespace Examine.Test.Examine.Lucene.Search
             Assert.AreEqual(3, facetResults3All.Count());
 
             // More interesting case: drill-down on two fields
-            var sc4 = taxonomySearcher.CreateQuery("content")
+            var sc4 = searcher.CreateQuery("content")
                .DrillDownQuery(
                 dims =>
                 {
@@ -5387,7 +5387,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
             // Even more interesting case: drill down on two fields,
             // but one of them is OR
-            var sc5 = taxonomySearcher.CreateQuery("content")
+            var sc5 = searcher.CreateQuery("content")
                .DrillDownQuery(
                 dims =>
                 {

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5262,6 +5262,7 @@ namespace Examine.Test.Examine.Lucene.Search
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
                         facets.FacetString("publishDate");
+                        facets.FacetString("Author");
                     }));
                 var results1 = sc.ExecuteWithLucene();
 
@@ -5271,7 +5272,11 @@ namespace Examine.Test.Examine.Lucene.Search
                 Assert.AreEqual(2, results1.Count());
                 Assert.AreEqual(2, facetResults1.Count());
 
-
+                // Author is drill-sideways + drill-down: Lisa
+                // (drill-down) published twice, and Frank/Susan/Bob
+                // published once:
+                var facetResults2 = results1.GetFacet("Author");
+                Assert.AreEqual(4, facetResults2.Count());
             }
         }
     }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5213,15 +5213,15 @@ namespace Examine.Test.Examine.Lucene.Search
             {
                 var items = new ValueSet[] {
                     ValueSet.FromObject("1", "content",
-                    new { publishDate = new object[]{ new object[] { "2010", "10", "15" } }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                      ValueSet.FromObject("2", "content",
-                    new { publishDate =  new object[]{ new object[] {"2010", "10", "20"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                       ValueSet.FromObject("3", "content",
-                    new { publishDate =  new object[]{ new object[] {"2012", "1", "1"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                        ValueSet.FromObject("4", "content",
-                    new { publishDate =  new object[]{ new object[] {"2012", "1", "7"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                         ValueSet.FromObject("5", "content",
-                    new { publishDate =  new object[]{ new object[] { "1999", "5", "5"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
                 };
 
                 indexer.IndexItems(items);

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5318,6 +5318,33 @@ namespace Examine.Test.Examine.Lucene.Search
                 var facetResults2Author = results2.GetFacet("Author");
                 Assert.AreEqual(4, facetResults1Author.Count());
 
+
+                // Publish Date is only drill-down: Lisa and Bob
+                // (drill-down) published twice in 2010 and once in 2012:
+                var sc3 = taxonomySearcher.CreateQuery("content")
+                   .DrillDownQuery(
+                    dims =>
+                    {
+                        dims.AddDimension("Author", "Lisa");
+                        dims.AddDimension("Author", "Bob");
+                    },
+                    null
+                   ,
+                   sideways =>
+                   {
+                       sideways.SetTopN(10);
+                   },
+                   BooleanOperation.Or)
+                   .WithFacets((Action<IFacetOperations>)(facets =>
+                   {
+                       facets.FacetAllDimensions(10);
+                   }));
+                var results3 = sc3.ExecuteWithLucene();
+                // Author is drill-sideways + drill-down: Lisa
+                // (drill-down) published twice, and Frank/Susan/Bob
+                // published once:
+                var facetResults3All = results3.GetFacets();
+                Assert.AreEqual(3, facetResults3All.Count());
             }
         }
     }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5192,10 +5192,7 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
-        [TestCase(FacetTestType.TaxonomyFacets)]
-        //[TestCase(FacetTestType.SortedSetFacets)]
-        //[TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5296,37 +5296,47 @@ namespace Examine.Test.Examine.Lucene.Search
         }
 
         [TestCase(FacetTestType.TaxonomyFacets)]
-        [TestCase(FacetTestType.SortedSetFacets)]
-        [TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
+        //[TestCase(FacetTestType.SortedSetFacets)]
+        //[TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();
             facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
-
-            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
+            //facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate"); //Not working
             facetConfigs.SetHierarchical("publishDate", true);
 
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
             using (var indexer = GetTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
                 new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("Author", FieldDefinitionTypes.FacetTaxonomyFullText),
                 new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
                 new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
 
                 ), facetsConfig: facetConfigs))
             {
                 var items = new ValueSet[] {
-                    ValueSet.FromObject("1", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    ValueSet.FromObject(
+                        "1",
+                        "content",
+                        new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }),
+                            nodeName = "umbraco",
+                            Author = "Bob",
+                            writerName = "administrator",
+                            taxonomynodeName = "umbraco" }),
                      ValueSet.FromObject("2", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ),
+                        nodeName = "umbraco", Author = "Lisa", writerName = "administrator", taxonomynodeName = "umbraco" }),
                       ValueSet.FromObject("3", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ),
+                        nodeName = "umbraco", Author = "Lisa", writerName = "administrator", taxonomynodeName = "umbraco" }),
                        ValueSet.FromObject("4", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}),
+                        nodeName = "umbraco", Author = "Susan", writerName = "administrator", taxonomynodeName = "umbraco" }),
                         ValueSet.FromObject("5", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ),
+                        nodeName = "umbraco", Author = "Frank", writerName = "administrator", taxonomynodeName = "umbraco" })
                 };
 
                 indexer.IndexItems(items);
@@ -5334,180 +5344,38 @@ namespace Examine.Test.Examine.Lucene.Search
                 var taxonomySearcher = indexer.TaxonomySearcher;
                 var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
 
-                //Arrange
-
-                var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                    dims =>
-                    {
-                        // Filter the nodePath to the 2010 category
-                        dims.AddDimension("publishDate", "2010", "10");
-                    },
-                    null,
-                    sideways =>
-                    {
-
-                    })
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate");
-                    }));
 
                 //Act
-
-                var results1 = sc.ExecuteWithLucene();
-
-                var facetResults1 = results1.GetFacet("publishDate");
-
-                Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(1, facetResults1.Count());
-            }
-        }
-
-
-        [TestCase(FacetTestType.TaxonomyFacets)]
-        [TestCase(FacetTestType.SortedSetFacets)]
-        [TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
-        {
-            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
-            var facetConfigs = new FacetsConfig();
-            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
-
-            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
-            facetConfigs.SetHierarchical("publishDate", true);
-
-            using (var luceneDir = new RandomIdRAMDirectory())
-            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
-            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
-                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
-
-                ), facetsConfig: facetConfigs))
-            {
-                var items = new ValueSet[] {
-                    ValueSet.FromObject("1", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                     ValueSet.FromObject("2", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                      ValueSet.FromObject("3", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                       ValueSet.FromObject("4", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                        ValueSet.FromObject("5", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
-                };
-
-                indexer.IndexItems(items);
-
-                var taxonomySearcher = indexer.TaxonomySearcher;
-                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
-
-                //Arrange
-
+                //  case: drill-down on a single field; in this
+                // case the drill-sideways + drill-down counts ==
+                // drill-down of just the query: 
                 var sc = taxonomySearcher.CreateQuery("content")
                     .DrillDownQuery(
                      dims =>
                      {
-                         // Filter the nodePath to the 2010 category
-                         dims.AddDimension("publishDate", "2010", "10");
+                         dims.AddDimension("Author", "Lisa");
                      },
-                     baseQuery =>
-                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
+                     null
                     ,
                     sideways =>
                     {
-
+                        sideways.SetTopN(10);
                     },
                     BooleanOperation.Or)
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
                         facets.FacetString("publishDate");
                     }));
-
-                //Act
-
                 var results1 = sc.ExecuteWithLucene();
 
                 var facetResults1 = results1.GetFacet("publishDate");
-
+                // Publish Date is only drill-down, and Lisa published
+                // one in 2012 and one in 2010:
                 Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(1, facetResults1.Count());
+                Assert.AreEqual(2, facetResults1.Count());
+
+
             }
         }
-
-        [TestCase(FacetTestType.TaxonomyFacets)]
-        [TestCase(FacetTestType.SortedSetFacets)]
-        [TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
-        {
-            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
-            var facetConfigs = new FacetsConfig();
-            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
-
-            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
-            facetConfigs.SetHierarchical("publishDate", true);
-
-            using (var luceneDir = new RandomIdRAMDirectory())
-            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
-            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
-                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
-                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
-
-                ), facetsConfig: facetConfigs))
-            {
-                var items = new ValueSet[] {
-                    ValueSet.FromObject("1", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                     ValueSet.FromObject("2", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                      ValueSet.FromObject("3", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                       ValueSet.FromObject("4", "content",
-                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
-                        ValueSet.FromObject("5", "content",
-                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
-                };
-
-                indexer.IndexItems(items);
-
-                var taxonomySearcher = indexer.TaxonomySearcher;
-                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
-
-                //Arrange
-
-                var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                    dims =>
-                    {
-                        // Filter the nodePath to the 2010 category
-                        dims.AddDimension("publishDate", "2010", "10");
-                    },
-                    baseQuery =>
-                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
-                    ,
-                    sideways =>
-                    {
-                        sideways.SetTopN(20);
-                    },
-                    BooleanOperation.Or)
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate");
-                    }));
-
-                //Act
-
-                var results1 = sc.ExecuteWithLucene();
-
-                var facetResults1 = results1.GetFacet("publishDate");
-
-                Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(1, facetResults1.Count());
-            }
-        }
-
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5335,11 +5335,13 @@ namespace Examine.Test.Examine.Lucene.Search
                 //Arrange
 
                 var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(dims =>
+                    .DrillDownQuery(
+                    dims =>
                     {
                         // Filter the nodePath to the 2010 category
                         dims.AddDimension("publishDate", "2010", "10");
                     },
+                    null,
                     sideways =>
                     {
 
@@ -5402,17 +5404,87 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 var sc = taxonomySearcher.CreateQuery("content")
                     .DrillDownQuery(
-                    baseQuery =>
+                     dims =>
+                     {
+                         // Filter the nodePath to the 2010 category
+                         dims.AddDimension("publishDate", "2010", "10");
+                     },
+                     baseQuery =>
                         baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
                     ,
+                    sideways =>
+                    {
+
+                    },
+                    BooleanOperation.Or)
+                    .WithFacets((Action<IFacetOperations>)(facets =>
+                    {
+                        facets.FacetString("publishDate");
+                    }));
+
+                //Act
+
+                var results1 = sc.ExecuteWithLucene();
+
+                var facetResults1 = results1.GetFacet("publishDate");
+
+                Assert.AreEqual(2, results1.Count());
+                Assert.AreEqual(1, facetResults1.Count());
+            }
+        }
+
+        [Test]
+        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            var facetConfigs = new FacetsConfig();
+            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
+
+            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
+            facetConfigs.SetHierarchical("publishDate", true);
+
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
+                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
+
+                ), facetsConfig: facetConfigs))
+            {
+                var items = new ValueSet[] {
+                    ValueSet.FromObject("1", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                     ValueSet.FromObject("2", "content",
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                      ValueSet.FromObject("3", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                       ValueSet.FromObject("4", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                        ValueSet.FromObject("5", "content",
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                };
+
+                indexer.IndexItems(items);
+
+                var taxonomySearcher = indexer.TaxonomySearcher;
+                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
+
+                //Arrange
+
+                var sc = taxonomySearcher.CreateQuery("content")
+                    .DrillDownQuery(
                     dims =>
                     {
                         // Filter the nodePath to the 2010 category
                         dims.AddDimension("publishDate", "2010", "10");
                     },
+                    baseQuery =>
+                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
+                    ,
                     sideways =>
                     {
-
+                        sideways.SetTopN(20);
                     },
                     BooleanOperation.Or)
                     .WithFacets((Action<IFacetOperations>)(facets =>

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5295,6 +5295,8 @@ namespace Examine.Test.Examine.Lucene.Search
             Assert.IsFalse(firstResults.Any(x => secondResults.Any(y => y.Id == x.Id)), "The second set of results should not contain the first set of results");
         }
 
+
+        [TestCase()]
         public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
@@ -5343,178 +5345,183 @@ namespace Examine.Test.Examine.Lucene.Search
 
 
                 //Act
-                //  case: drill-down on a single field; in this
-                // case the drill-sideways + drill-down counts ==
-                // drill-down of just the query: 
-                var sc = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                     dims =>
-                     {
-                         dims.AddDimension("Author", "Lisa");
-                     },
-                     null
-                    ,
-                    sideways =>
-                    {
-                        sideways.SetTopN(10);
-                    },
-                    BooleanOperation.Or)
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate", x => x.MaxCount(10));
-                        facets.FacetString("Author", x => x.MaxCount(10));
-                    }));
-                var results1 = sc.ExecuteWithLucene();
-
-                Assert.AreEqual(2, results1.Count());
-
-                var facetResults1PublishDate = results1.GetFacet("publishDate");
-                // Publish Date is only drill-down, and Lisa published
-                // one in 2012 and one in 2010:
-                Assert.AreEqual(2, facetResults1PublishDate.Count());
-
-                // Author is drill-sideways + drill-down: Lisa
-                // (drill-down) published twice, and Frank/Susan/Bob
-                // published once:
-                var facetResults1Author = results1.GetFacet("Author");
-                Assert.AreEqual(4, facetResults1Author.Count());
-
-                // Another simple case: drill-down on single fields
-                // but OR of two values
-                //Act
-                //  case: drill-down on a single field; in this
-                // case the drill-sideways + drill-down counts ==
-                // drill-down of just the query: 
-                var sc2 = taxonomySearcher.CreateQuery("content")
-                    .DrillDownQuery(
-                     dims =>
-                     {
-                         dims.AddDimension("Author", "Lisa");
-                         dims.AddDimension("Author", "Bob");
-                     },
-                     null
-                    ,
-                    sideways =>
-                    {
-                        sideways.SetTopN(10);
-                    },
-                    BooleanOperation.Or)
-                    .WithFacets((Action<IFacetOperations>)(facets =>
-                    {
-                        facets.FacetString("publishDate", x => x.MaxCount(10));
-                        facets.FacetString("Author", x => x.MaxCount(10));
-                    }));
-                var results2 = sc2.ExecuteWithLucene();
-                Assert.AreEqual(3, results2.Count());
-
-                // Publish Date is only drill-down: Lisa and Bob
-                // (drill-down) published twice in 2010 and once in 2012:
-                var facetResults2PublishDate = results2.GetFacet("publishDate");
-                Assert.AreEqual(2, facetResults2PublishDate.Count());
-
-                // Author is drill-sideways + drill-down: Lisa
-                // (drill-down) published twice, and Frank/Susan/Bob
-                // published once:
-                var facetResults2Author = results2.GetFacet("Author");
-                Assert.AreEqual(4, facetResults2Author.Count());
-
-
-                // Publish Date is only drill-down: Lisa and Bob
-                // (drill-down) published twice in 2010 and once in 2012:
-                var sc3 = taxonomySearcher.CreateQuery("content")
-                   .DrillDownQuery(
-                    dims =>
-                    {
-                        dims.AddDimension("Author", "Lisa");
-                        dims.AddDimension("Author", "Bob");
-                    },
-                    null
-                   ,
-                   sideways =>
-                   {
-                       sideways.SetTopN(10);
-                   },
-                   BooleanOperation.Or)
-                   .WithFacets((Action<IFacetOperations>)(facets =>
-                   {
-                       facets.FacetAllDimensions(10);
-                   }));
-                var results3 = sc3.ExecuteWithLucene();
-                // Author is drill-sideways + drill-down: Lisa
-                // (drill-down) published twice, and Frank/Susan/Bob
-                // published once:
-                var facetResults3All = results3.GetFacets();
-                Assert.AreEqual(3, facetResults3All.Count());
-
-                // More interesting case: drill-down on two fields
-                var sc4 = taxonomySearcher.CreateQuery("content")
-                   .DrillDownQuery(
-                    dims =>
-                    {
-                        dims.AddDimension("Author", "Lisa");
-                        dims.AddDimension("publishDate", "2010");
-                    },
-                    null
-                   ,
-                   sideways =>
-                   {
-                       sideways.SetTopN(10);
-                   },
-                   BooleanOperation.Or)
-                   .WithFacets((Action<IFacetOperations>)(facets =>
-                   {
-                       facets.FacetString("publishDate", x => x.MaxCount(10));
-                       facets.FacetString("Author", x => x.MaxCount(10));
-                   }));
-                var results4 = sc4.ExecuteWithLucene();
-                Assert.AreEqual(1, results4.Count());
-
-                // Publish Date is drill-sideways + drill-down: Lisa
-                // (drill-down) published once in 2010 and once in 2012:
-                var facetResults4PublishDate = results4.GetFacet("publishDate");
-                Assert.AreEqual(2, facetResults4PublishDate.Count());
-
-                // Author is drill-sideways + drill-down:
-                // only Lisa & Bob published (once each) in 2010:
-                var facetResults4Author = results4.GetFacet("Author");
-                Assert.AreEqual(2, facetResults4Author.Count());
-
-
-                // Even more interesting case: drill down on two fields,
-                // but one of them is OR
-                var sc5 = taxonomySearcher.CreateQuery("content")
-                   .DrillDownQuery(
-                    dims =>
-                    {
-                        dims.AddDimension("Author", "Lisa");
-                        dims.AddDimension("publishDate", "2010");
-                        dims.AddDimension("Author", "Bob");
-                    },
-                    null
-                   ,
-                   sideways =>
-                   {
-                       sideways.SetTopN(10);
-                   },
-                   BooleanOperation.Or)
-                   .WithFacets((Action<IFacetOperations>)(facets =>
-                   {
-                       facets.FacetString("publishDate", x => x.MaxCount(10));
-                       facets.FacetString("Author", x => x.MaxCount(10));
-                   }));
-                var results5 = sc5.ExecuteWithLucene();
-                Assert.AreEqual(2, results5.Count());
-
-                // Publish Date is both drill-sideways + drill-down:
-                // Lisa or Bob published twice in 2010 and once in 2012:
-                var facetResults5PublishDate = results5.GetFacet("publishDate");
-                Assert.AreEqual(2, facetResults5PublishDate.Count());
-
-                // Author is drill-sideways + drill-down:
-                // only Lisa & Bob published (once each) in 2010:
-                var facetResults5Author = results5.GetFacet("Author");
-                Assert.AreEqual(2, facetResults5Author.Count());
+                BasicDrillSidewaysTests(taxonomySearcher);
             }
+        }
+
+        private static void BasicDrillSidewaysTests(ISearcher taxonomySearcher)
+        {
+            //  case: drill-down on a single field; in this
+            // case the drill-sideways + drill-down counts ==
+            // drill-down of just the query: 
+            var sc = taxonomySearcher.CreateQuery("content")
+                .DrillDownQuery(
+                 dims =>
+                 {
+                     dims.AddDimension("Author", "Lisa");
+                 },
+                 null
+                ,
+                sideways =>
+                {
+                    sideways.SetTopN(10);
+                },
+                BooleanOperation.Or)
+                .WithFacets((Action<IFacetOperations>)(facets =>
+                {
+                    facets.FacetString("publishDate", x => x.MaxCount(10));
+                    facets.FacetString("Author", x => x.MaxCount(10));
+                }));
+            var results1 = sc.ExecuteWithLucene();
+
+            Assert.AreEqual(2, results1.Count());
+
+            var facetResults1PublishDate = results1.GetFacet("publishDate");
+            // Publish Date is only drill-down, and Lisa published
+            // one in 2012 and one in 2010:
+            Assert.AreEqual(2, facetResults1PublishDate.Count());
+
+            // Author is drill-sideways + drill-down: Lisa
+            // (drill-down) published twice, and Frank/Susan/Bob
+            // published once:
+            var facetResults1Author = results1.GetFacet("Author");
+            Assert.AreEqual(4, facetResults1Author.Count());
+
+            // Another simple case: drill-down on single fields
+            // but OR of two values
+            //Act
+            //  case: drill-down on a single field; in this
+            // case the drill-sideways + drill-down counts ==
+            // drill-down of just the query: 
+            var sc2 = taxonomySearcher.CreateQuery("content")
+                .DrillDownQuery(
+                 dims =>
+                 {
+                     dims.AddDimension("Author", "Lisa");
+                     dims.AddDimension("Author", "Bob");
+                 },
+                 null
+                ,
+                sideways =>
+                {
+                    sideways.SetTopN(10);
+                },
+                BooleanOperation.Or)
+                .WithFacets((Action<IFacetOperations>)(facets =>
+                {
+                    facets.FacetString("publishDate", x => x.MaxCount(10));
+                    facets.FacetString("Author", x => x.MaxCount(10));
+                }));
+            var results2 = sc2.ExecuteWithLucene();
+            Assert.AreEqual(3, results2.Count());
+
+            // Publish Date is only drill-down: Lisa and Bob
+            // (drill-down) published twice in 2010 and once in 2012:
+            var facetResults2PublishDate = results2.GetFacet("publishDate");
+            Assert.AreEqual(2, facetResults2PublishDate.Count());
+
+            // Author is drill-sideways + drill-down: Lisa
+            // (drill-down) published twice, and Frank/Susan/Bob
+            // published once:
+            var facetResults2Author = results2.GetFacet("Author");
+            Assert.AreEqual(4, facetResults2Author.Count());
+
+
+            // Publish Date is only drill-down: Lisa and Bob
+            // (drill-down) published twice in 2010 and once in 2012:
+            var sc3 = taxonomySearcher.CreateQuery("content")
+               .DrillDownQuery(
+                dims =>
+                {
+                    dims.AddDimension("Author", "Lisa");
+                    dims.AddDimension("Author", "Bob");
+                },
+                null
+               ,
+               sideways =>
+               {
+                   sideways.SetTopN(10);
+               },
+               BooleanOperation.Or)
+               .WithFacets((Action<IFacetOperations>)(facets =>
+               {
+                   facets.FacetAllDimensions(10);
+               }));
+            var results3 = sc3.ExecuteWithLucene();
+            // Author is drill-sideways + drill-down: Lisa
+            // (drill-down) published twice, and Frank/Susan/Bob
+            // published once:
+            var facetResults3All = results3.GetFacets();
+            Assert.AreEqual(3, facetResults3All.Count());
+
+            // More interesting case: drill-down on two fields
+            var sc4 = taxonomySearcher.CreateQuery("content")
+               .DrillDownQuery(
+                dims =>
+                {
+                    dims.AddDimension("Author", "Lisa");
+                    dims.AddDimension("publishDate", "2010");
+                },
+                null
+               ,
+               sideways =>
+               {
+                   sideways.SetTopN(10);
+               },
+               BooleanOperation.Or)
+               .WithFacets((Action<IFacetOperations>)(facets =>
+               {
+                   facets.FacetString("publishDate", x => x.MaxCount(10));
+                   facets.FacetString("Author", x => x.MaxCount(10));
+               }));
+            var results4 = sc4.ExecuteWithLucene();
+            Assert.AreEqual(1, results4.Count());
+
+            // Publish Date is drill-sideways + drill-down: Lisa
+            // (drill-down) published once in 2010 and once in 2012:
+            var facetResults4PublishDate = results4.GetFacet("publishDate");
+            Assert.AreEqual(2, facetResults4PublishDate.Count());
+
+            // Author is drill-sideways + drill-down:
+            // only Lisa & Bob published (once each) in 2010:
+            var facetResults4Author = results4.GetFacet("Author");
+            Assert.AreEqual(2, facetResults4Author.Count());
+
+
+            // Even more interesting case: drill down on two fields,
+            // but one of them is OR
+            var sc5 = taxonomySearcher.CreateQuery("content")
+               .DrillDownQuery(
+                dims =>
+                {
+                    dims.AddDimension("Author", "Lisa");
+                    dims.AddDimension("publishDate", "2010");
+                    dims.AddDimension("Author", "Bob");
+                },
+                null
+               ,
+               sideways =>
+               {
+                   sideways.SetTopN(10);
+               },
+               BooleanOperation.Or)
+               .WithFacets((Action<IFacetOperations>)(facets =>
+               {
+                   facets.FacetString("publishDate", x => x.MaxCount(10));
+                   facets.FacetString("Author", x => x.MaxCount(10));
+               }));
+            var results5 = sc5.ExecuteWithLucene();
+            Assert.AreEqual(2, results5.Count());
+
+            // Publish Date is both drill-sideways + drill-down:
+            // Lisa or Bob published twice in 2010 and once in 2012:
+            var facetResults5PublishDate = results5.GetFacet("publishDate");
+            Assert.AreEqual(2, facetResults5PublishDate.Count());
+
+            // Author is drill-sideways + drill-down:
+            // only Lisa & Bob published (once each) in 2010:
+            var facetResults5Author = results5.GetFacet("Author");
+            Assert.AreEqual(2, facetResults5Author.Count());
         }
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5294,5 +5294,67 @@ namespace Examine.Test.Examine.Lucene.Search
             var secondResults = results2.ToArray();
             Assert.IsFalse(firstResults.Any(x => secondResults.Any(y => y.Id == x.Id)), "The second set of results should not contain the first set of results");
         }
+
+        [Test]
+        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            var facetConfigs = new FacetsConfig();
+            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
+
+            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
+            facetConfigs.SetHierarchical("publishDate", true);
+
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
+                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
+
+                ), facetsConfig: facetConfigs))
+            {
+                var items = new ValueSet[] {
+                    ValueSet.FromObject("1", "content",
+                    new { publishDate = new object[]{ new object[] { "2010", "10", "15" } }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                     ValueSet.FromObject("2", "content",
+                    new { publishDate =  new object[]{ new object[] {"2010", "10", "20"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                      ValueSet.FromObject("3", "content",
+                    new { publishDate =  new object[]{ new object[] {"2012", "1", "1"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                       ValueSet.FromObject("4", "content",
+                    new { publishDate =  new object[]{ new object[] {"2012", "1", "7"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                        ValueSet.FromObject("5", "content",
+                    new { publishDate =  new object[]{ new object[] { "1999", "5", "5"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                };
+
+                indexer.IndexItems(items);
+
+                var taxonomySearcher = indexer.TaxonomySearcher;
+                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
+
+                //Arrange
+
+                var sc = taxonomySearcher.CreateQuery("content")
+                    .DrillDownQuery(dims =>
+                    {
+                        // Filter the nodePath to the 2010 category
+                        dims.AddDimension("publishDate", "2010");
+                    })
+                    .WithFacets((Action<IFacetOperations>)(facets =>
+                    {
+                        facets.FacetString("publishDate");
+                    }));
+
+                //Act
+
+                var results1 = sc.ExecuteWithLucene();
+
+                var facetResults1 = results1.GetFacet("publishDate");
+
+                Assert.AreEqual(2, results1.Count());
+                Assert.AreEqual(1, facetResults1.Count());
+            }
+        }
+
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5295,10 +5295,7 @@ namespace Examine.Test.Examine.Lucene.Search
             Assert.IsFalse(firstResults.Any(x => secondResults.Any(y => y.Id == x.Id)), "The second set of results should not contain the first set of results");
         }
 
-        [TestCase(FacetTestType.TaxonomyFacets)]
-        //[TestCase(FacetTestType.SortedSetFacets)]
-        //[TestCase(FacetTestType.NoFacets)]
-        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5295,8 +5295,10 @@ namespace Examine.Test.Examine.Lucene.Search
             Assert.IsFalse(firstResults.Any(x => secondResults.Any(y => y.Id == x.Id)), "The second set of results should not contain the first set of results");
         }
 
-        [Test]
-        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet()
+        [TestCase(FacetTestType.TaxonomyFacets)]
+        [TestCase(FacetTestType.SortedSetFacets)]
+        [TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDown_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();
@@ -5363,8 +5365,10 @@ namespace Examine.Test.Examine.Lucene.Search
         }
 
 
-        [Test]
-        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
+        [TestCase(FacetTestType.TaxonomyFacets)]
+        [TestCase(FacetTestType.SortedSetFacets)]
+        [TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();
@@ -5433,8 +5437,10 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
-        [Test]
-        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet()
+        [TestCase(FacetTestType.TaxonomyFacets)]
+        [TestCase(FacetTestType.SortedSetFacets)]
+        [TestCase(FacetTestType.NoFacets)]
+        public void GivenTaxonomyIndexFacetDrillDownSubquerySideways_Returns_ExpectedTotals_Facet(FacetTestType withFacets)
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
             var facetConfigs = new FacetsConfig();

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5349,12 +5349,12 @@ namespace Examine.Test.Examine.Lucene.Search
             }
         }
 
-        private static void BasicDrillSidewaysTests(ISearcher taxonomySearcher)
+        private static void BasicDrillSidewaysTests(ISearcher searcher)
         {
             //  case: drill-down on a single field; in this
             // case the drill-sideways + drill-down counts ==
             // drill-down of just the query: 
-            var sc = taxonomySearcher.CreateQuery("content")
+            var sc = searcher.CreateQuery("content")
                 .DrillDownQuery(
                  dims =>
                  {
@@ -5393,7 +5393,7 @@ namespace Examine.Test.Examine.Lucene.Search
             //  case: drill-down on a single field; in this
             // case the drill-sideways + drill-down counts ==
             // drill-down of just the query: 
-            var sc2 = taxonomySearcher.CreateQuery("content")
+            var sc2 = searcher.CreateQuery("content")
                 .DrillDownQuery(
                  dims =>
                  {
@@ -5429,7 +5429,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
             // Publish Date is only drill-down: Lisa and Bob
             // (drill-down) published twice in 2010 and once in 2012:
-            var sc3 = taxonomySearcher.CreateQuery("content")
+            var sc3 = searcher.CreateQuery("content")
                .DrillDownQuery(
                 dims =>
                 {
@@ -5455,7 +5455,7 @@ namespace Examine.Test.Examine.Lucene.Search
             Assert.AreEqual(3, facetResults3All.Count());
 
             // More interesting case: drill-down on two fields
-            var sc4 = taxonomySearcher.CreateQuery("content")
+            var sc4 = searcher.CreateQuery("content")
                .DrillDownQuery(
                 dims =>
                 {
@@ -5490,7 +5490,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
             // Even more interesting case: drill down on two fields,
             // but one of them is OR
-            var sc5 = taxonomySearcher.CreateQuery("content")
+            var sc5 = searcher.CreateQuery("content")
                .DrillDownQuery(
                 dims =>
                 {

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5364,22 +5364,63 @@ namespace Examine.Test.Examine.Lucene.Search
                     BooleanOperation.Or)
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
-                        facets.FacetString("publishDate");
-                        facets.FacetString("Author");
+                        facets.FacetString("publishDate", x => x.MaxCount(10));
+                        facets.FacetString("Author", x => x.MaxCount(10));
                     }));
                 var results1 = sc.ExecuteWithLucene();
 
-                var facetResults1 = results1.GetFacet("publishDate");
+                Assert.AreEqual(2, results1.Count());
+
+                var facetResults1PublishDate = results1.GetFacet("publishDate");
                 // Publish Date is only drill-down, and Lisa published
                 // one in 2012 and one in 2010:
-                Assert.AreEqual(2, results1.Count());
-                Assert.AreEqual(2, facetResults1.Count());
+                Assert.AreEqual(2, facetResults1PublishDate.Count());
 
                 // Author is drill-sideways + drill-down: Lisa
                 // (drill-down) published twice, and Frank/Susan/Bob
                 // published once:
-                var facetResults2 = results1.GetFacet("Author");
-                Assert.AreEqual(4, facetResults2.Count());
+                var facetResults1Author = results1.GetFacet("Author");
+                Assert.AreEqual(4, facetResults1Author.Count());
+
+                // Another simple case: drill-down on single fields
+                // but OR of two values
+                //Act
+                //  case: drill-down on a single field; in this
+                // case the drill-sideways + drill-down counts ==
+                // drill-down of just the query: 
+                var sc2 = taxonomySearcher.CreateQuery("content")
+                    .DrillDownQuery(
+                     dims =>
+                     {
+                         dims.AddDimension("Author", "Lisa");
+                         dims.AddDimension("Author", "Bob");
+                     },
+                     null
+                    ,
+                    sideways =>
+                    {
+                        sideways.SetTopN(10);
+                    },
+                    BooleanOperation.Or)
+                    .WithFacets((Action<IFacetOperations>)(facets =>
+                    {
+                        facets.FacetString("publishDate", x => x.MaxCount(10));
+                        facets.FacetString("Author", x => x.MaxCount(10));
+                    }));
+                var results2 = sc2.ExecuteWithLucene();
+                Assert.AreEqual(3, results2.Count());
+
+                // Publish Date is only drill-down: Lisa and Bob
+                // (drill-down) published twice in 2010 and once in 2012:
+                var facetResults2PublishDate = results2.GetFacet("publishDate");
+                Assert.AreEqual(2, facetResults2PublishDate.Count());
+
+                // Author is drill-sideways + drill-down: Lisa
+                // (drill-down) published twice, and Frank/Susan/Bob
+                // published once:
+                var facetResults2Author = results2.GetFacet("Author");
+                Assert.AreEqual(4, facetResults1Author.Count());
+
             }
         }
     }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5421,6 +5421,33 @@ namespace Examine.Test.Examine.Lucene.Search
                 var facetResults2Author = results2.GetFacet("Author");
                 Assert.AreEqual(4, facetResults1Author.Count());
 
+
+                // Publish Date is only drill-down: Lisa and Bob
+                // (drill-down) published twice in 2010 and once in 2012:
+                var sc3 = taxonomySearcher.CreateQuery("content")
+                   .DrillDownQuery(
+                    dims =>
+                    {
+                        dims.AddDimension("Author", "Lisa");
+                        dims.AddDimension("Author", "Bob");
+                    },
+                    null
+                   ,
+                   sideways =>
+                   {
+                       sideways.SetTopN(10);
+                   },
+                   BooleanOperation.Or)
+                   .WithFacets((Action<IFacetOperations>)(facets =>
+                   {
+                       facets.FacetAllDimensions(10);
+                   }));
+                var results3 = sc3.ExecuteWithLucene();
+                // Author is drill-sideways + drill-down: Lisa
+                // (drill-down) published twice, and Frank/Susan/Bob
+                // published once:
+                var facetResults3All = results3.GetFacets();
+                Assert.AreEqual(3, facetResults3All.Count());
             }
         }
     }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5307,7 +5307,7 @@ namespace Examine.Test.Examine.Lucene.Search
 
             using (var luceneDir = new RandomIdRAMDirectory())
             using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
-            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
+            using (var indexer = GetTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
                 new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
                 new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
                 new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
@@ -5338,8 +5338,83 @@ namespace Examine.Test.Examine.Lucene.Search
                     .DrillDownQuery(dims =>
                     {
                         // Filter the nodePath to the 2010 category
-                        dims.AddDimension("publishDate", "2010");
+                        dims.AddDimension("publishDate", "2010", "10");
+                    },
+                    sideways =>
+                    {
+
                     })
+                    .WithFacets((Action<IFacetOperations>)(facets =>
+                    {
+                        facets.FacetString("publishDate");
+                    }));
+
+                //Act
+
+                var results1 = sc.ExecuteWithLucene();
+
+                var facetResults1 = results1.GetFacet("publishDate");
+
+                Assert.AreEqual(2, results1.Count());
+                Assert.AreEqual(1, facetResults1.Count());
+            }
+        }
+
+
+        [Test]
+        public void GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            var facetConfigs = new FacetsConfig();
+            facetConfigs.SetIndexFieldName("taxonomynodeName", "taxonomy_nodeName");
+
+            facetConfigs.SetIndexFieldName("publishDate", "taxonomy_publishDate");
+            facetConfigs.SetHierarchical("publishDate", true);
+
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var luceneTaxonomyDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTaxonomyTestIndex(luceneDir, luceneTaxonomyDir, analyzer, new FieldDefinitionCollection(
+                new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("nodeName", FieldDefinitionTypes.FacetTaxonomyFullText),
+                new FieldDefinition("taxonomynodeName", FieldDefinitionTypes.FacetTaxonomyFullText)
+
+                ), facetsConfig: facetConfigs))
+            {
+                var items = new ValueSet[] {
+                    ValueSet.FromObject("1", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                     ValueSet.FromObject("2", "content",
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                      ValueSet.FromObject("3", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                       ValueSet.FromObject("4", "content",
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                        ValueSet.FromObject("5", "content",
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                };
+
+                indexer.IndexItems(items);
+
+                var taxonomySearcher = indexer.TaxonomySearcher;
+                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
+
+                //Arrange
+
+                var sc = taxonomySearcher.CreateQuery("content")
+                    .DrillDownQuery(
+                    baseQuery =>
+                        baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content")
+                    ,
+                    dims =>
+                    {
+                        // Filter the nodePath to the 2010 category
+                        dims.AddDimension("publishDate", "2010", "10");
+                    },
+                    sideways =>
+                    {
+
+                    },
+                    BooleanOperation.Or)
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
                         facets.FacetString("publishDate");

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5316,15 +5316,15 @@ namespace Examine.Test.Examine.Lucene.Search
             {
                 var items = new ValueSet[] {
                     ValueSet.FromObject("1", "content",
-                    new { publishDate = new object[]{ new object[] { "2010", "10", "15" } }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2010", "10", "15" }), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                      ValueSet.FromObject("2", "content",
-                    new { publishDate =  new object[]{ new object[] {"2010", "10", "20"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate =  new FacetLabel("publishDate", new string[]  {"2010", "10", "20"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                       ValueSet.FromObject("3", "content",
-                    new { publishDate =  new object[]{ new object[] {"2012", "1", "1"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "1"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                        ValueSet.FromObject("4", "content",
-                    new { publishDate =  new object[]{ new object[] {"2012", "1", "7"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
+                    new { publishDate = new FacetLabel("publishDate", new string[] { "2012", "1", "7"}), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" }),
                         ValueSet.FromObject("5", "content",
-                    new { publishDate =  new object[]{ new object[] { "1999", "5", "5"} }, nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
+                    new { publishDate =  new FacetLabel("publishDate", new string[] { "1999", "5", "5"} ), nodeName = "umbraco", headerText = "world", writerName = "administrator", taxonomynodeName = "umbraco" })
                 };
 
                 indexer.IndexItems(items);

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5419,7 +5419,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 // (drill-down) published twice, and Frank/Susan/Bob
                 // published once:
                 var facetResults2Author = results2.GetFacet("Author");
-                Assert.AreEqual(4, facetResults1Author.Count());
+                Assert.AreEqual(4, facetResults2Author.Count());
 
 
                 // Publish Date is only drill-down: Lisa and Bob
@@ -5448,6 +5448,75 @@ namespace Examine.Test.Examine.Lucene.Search
                 // published once:
                 var facetResults3All = results3.GetFacets();
                 Assert.AreEqual(3, facetResults3All.Count());
+
+                // More interesting case: drill-down on two fields
+                var sc4 = taxonomySearcher.CreateQuery("content")
+                   .DrillDownQuery(
+                    dims =>
+                    {
+                        dims.AddDimension("Author", "Lisa");
+                        dims.AddDimension("publishDate", "2010");
+                    },
+                    null
+                   ,
+                   sideways =>
+                   {
+                       sideways.SetTopN(10);
+                   },
+                   BooleanOperation.Or)
+                   .WithFacets((Action<IFacetOperations>)(facets =>
+                   {
+                       facets.FacetString("publishDate", x => x.MaxCount(10));
+                       facets.FacetString("Author", x => x.MaxCount(10));
+                   }));
+                var results4 = sc4.ExecuteWithLucene();
+                Assert.AreEqual(1, results4.Count());
+
+                // Publish Date is drill-sideways + drill-down: Lisa
+                // (drill-down) published once in 2010 and once in 2012:
+                var facetResults4PublishDate = results4.GetFacet("publishDate");
+                Assert.AreEqual(2, facetResults4PublishDate.Count());
+
+                // Author is drill-sideways + drill-down:
+                // only Lisa & Bob published (once each) in 2010:
+                var facetResults4Author = results4.GetFacet("Author");
+                Assert.AreEqual(2, facetResults4Author.Count());
+
+
+                // Even more interesting case: drill down on two fields,
+                // but one of them is OR
+                var sc5 = taxonomySearcher.CreateQuery("content")
+                   .DrillDownQuery(
+                    dims =>
+                    {
+                        dims.AddDimension("Author", "Lisa");
+                        dims.AddDimension("publishDate", "2010");
+                        dims.AddDimension("Author", "Bob");
+                    },
+                    null
+                   ,
+                   sideways =>
+                   {
+                       sideways.SetTopN(10);
+                   },
+                   BooleanOperation.Or)
+                   .WithFacets((Action<IFacetOperations>)(facets =>
+                   {
+                       facets.FacetString("publishDate", x => x.MaxCount(10));
+                       facets.FacetString("Author", x => x.MaxCount(10));
+                   }));
+                var results5 = sc5.ExecuteWithLucene();
+                Assert.AreEqual(2, results5.Count());
+
+                // Publish Date is both drill-sideways + drill-down:
+                // Lisa or Bob published twice in 2010 and once in 2012:
+                var facetResults5PublishDate = results5.GetFacet("publishDate");
+                Assert.AreEqual(2, facetResults5PublishDate.Count());
+
+                // Author is drill-sideways + drill-down:
+                // only Lisa & Bob published (once each) in 2010:
+                var facetResults5Author = results5.GetFacet("Author");
+                Assert.AreEqual(2, facetResults5Author.Count());
             }
         }
     }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5340,8 +5340,8 @@ namespace Examine.Test.Examine.Lucene.Search
 
                 indexer.IndexItems(items);
 
-                var taxonomySearcher = indexer.TaxonomySearcher;
-                var taxonomyCategoryCount = taxonomySearcher.CategoryCount;
+                var taxonomySearcher = indexer.TaxonomySearcher ?? throw new InvalidOperationException("TaxonomySearcher cannot be null");
+
 
 
                 //Act
@@ -5356,16 +5356,10 @@ namespace Examine.Test.Examine.Lucene.Search
             // drill-down of just the query: 
             var sc = searcher.CreateQuery("content")
                 .DrillDownQuery(
-                 dims =>
-                 {
-                     dims.AddDimension("Author", "Lisa");
-                 },
+                 dims => dims.AddDimension("Author", "Lisa"),
                  null
                 ,
-                sideways =>
-                {
-                    sideways.SetTopN(10);
-                },
+                sideways => sideways.SetTopN(10),
                 BooleanOperation.Or)
                 .WithFacets((Action<IFacetOperations>)(facets =>
                 {
@@ -5377,15 +5371,16 @@ namespace Examine.Test.Examine.Lucene.Search
             Assert.AreEqual(2, results1.Count());
 
             var facetResults1PublishDate = results1.GetFacet("publishDate");
+
             // Publish Date is only drill-down, and Lisa published
             // one in 2012 and one in 2010:
-            Assert.AreEqual(2, facetResults1PublishDate.Count());
+            Assert.AreEqual(2, facetResults1PublishDate?.Count());
 
             // Author is drill-sideways + drill-down: Lisa
             // (drill-down) published twice, and Frank/Susan/Bob
             // published once:
             var facetResults1Author = results1.GetFacet("Author");
-            Assert.AreEqual(4, facetResults1Author.Count());
+            Assert.AreEqual(4, facetResults1Author?.Count());
 
             // Another simple case: drill-down on single fields
             // but OR of two values
@@ -5402,10 +5397,7 @@ namespace Examine.Test.Examine.Lucene.Search
                  },
                  null
                 ,
-                sideways =>
-                {
-                    sideways.SetTopN(10);
-                },
+                sideways => sideways.SetTopN(10),
                 BooleanOperation.Or)
                 .WithFacets((Action<IFacetOperations>)(facets =>
                 {
@@ -5418,13 +5410,13 @@ namespace Examine.Test.Examine.Lucene.Search
             // Publish Date is only drill-down: Lisa and Bob
             // (drill-down) published twice in 2010 and once in 2012:
             var facetResults2PublishDate = results2.GetFacet("publishDate");
-            Assert.AreEqual(2, facetResults2PublishDate.Count());
+            Assert.AreEqual(2, facetResults2PublishDate?.Count());
 
             // Author is drill-sideways + drill-down: Lisa
             // (drill-down) published twice, and Frank/Susan/Bob
             // published once:
             var facetResults2Author = results2.GetFacet("Author");
-            Assert.AreEqual(4, facetResults2Author.Count());
+            Assert.AreEqual(4, facetResults2Author?.Count());
 
 
             // Publish Date is only drill-down: Lisa and Bob
@@ -5438,15 +5430,9 @@ namespace Examine.Test.Examine.Lucene.Search
                 },
                 null
                ,
-               sideways =>
-               {
-                   sideways.SetTopN(10);
-               },
+               sideways => sideways.SetTopN(10),
                BooleanOperation.Or)
-               .WithFacets((Action<IFacetOperations>)(facets =>
-               {
-                   facets.FacetAllDimensions(10);
-               }));
+               .WithFacets((Action<IFacetOperations>)(facets => facets.FacetAllDimensions(10)));
             var results3 = sc3.ExecuteWithLucene();
             // Author is drill-sideways + drill-down: Lisa
             // (drill-down) published twice, and Frank/Susan/Bob
@@ -5464,10 +5450,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 },
                 null
                ,
-               sideways =>
-               {
-                   sideways.SetTopN(10);
-               },
+               sideways => sideways.SetTopN(10),
                BooleanOperation.Or)
                .WithFacets((Action<IFacetOperations>)(facets =>
                {
@@ -5480,12 +5463,12 @@ namespace Examine.Test.Examine.Lucene.Search
             // Publish Date is drill-sideways + drill-down: Lisa
             // (drill-down) published once in 2010 and once in 2012:
             var facetResults4PublishDate = results4.GetFacet("publishDate");
-            Assert.AreEqual(2, facetResults4PublishDate.Count());
+            Assert.AreEqual(2, facetResults4PublishDate?.Count());
 
             // Author is drill-sideways + drill-down:
             // only Lisa & Bob published (once each) in 2010:
             var facetResults4Author = results4.GetFacet("Author");
-            Assert.AreEqual(2, facetResults4Author.Count());
+            Assert.AreEqual(2, facetResults4Author?.Count());
 
 
             // Even more interesting case: drill down on two fields,
@@ -5500,10 +5483,7 @@ namespace Examine.Test.Examine.Lucene.Search
                 },
                 null
                ,
-               sideways =>
-               {
-                   sideways.SetTopN(10);
-               },
+               sideways => sideways.SetTopN(10),
                BooleanOperation.Or)
                .WithFacets((Action<IFacetOperations>)(facets =>
                {
@@ -5516,12 +5496,12 @@ namespace Examine.Test.Examine.Lucene.Search
             // Publish Date is both drill-sideways + drill-down:
             // Lisa or Bob published twice in 2010 and once in 2012:
             var facetResults5PublishDate = results5.GetFacet("publishDate");
-            Assert.AreEqual(2, facetResults5PublishDate.Count());
+            Assert.AreEqual(2, facetResults5PublishDate?.Count());
 
             // Author is drill-sideways + drill-down:
             // only Lisa & Bob published (once each) in 2010:
             var facetResults5Author = results5.GetFacet("Author");
-            Assert.AreEqual(2, facetResults5Author.Count());
+            Assert.AreEqual(2, facetResults5Author?.Count());
         }
     }
 }

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5365,6 +5365,7 @@ namespace Examine.Test.Examine.Lucene.Search
                     .WithFacets((Action<IFacetOperations>)(facets =>
                     {
                         facets.FacetString("publishDate");
+                        facets.FacetString("Author");
                     }));
                 var results1 = sc.ExecuteWithLucene();
 
@@ -5374,7 +5375,11 @@ namespace Examine.Test.Examine.Lucene.Search
                 Assert.AreEqual(2, results1.Count());
                 Assert.AreEqual(2, facetResults1.Count());
 
-
+                // Author is drill-sideways + drill-down: Lisa
+                // (drill-down) published twice, and Frank/Susan/Bob
+                // published once:
+                var facetResults2 = results1.GetFacet("Author");
+                Assert.AreEqual(4, facetResults2.Count());
             }
         }
     }


### PR DESCRIPTION
Adds support for Facet Drill Down and Drill Sideways
Adds tests for Facet Drill Down and Drill Sideways
See GivenTaxonomyIndexFacetDrillDownSubquery_Returns_ExpectedTotals_Facet test for usage.
Add examples to docs

### DrillDown Query

DrillDown query is used to drill down and sideways on facets.

#### Basic MatchAll Query example

```csharp
// Setup
// Create a config
var facetsConfig = new FacetsConfig();
facetConfigs.SetHierarchical("publishDate", true);

services.AddExamineLuceneIndex("MyIndex",
    // Set the indexing of your fields to use the facet type
    fieldDefinitions: new FieldDefinitionCollection(
        new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
        new FieldDefinition("Author", FieldDefinitionTypes.FacetTaxonomyFullText)
        ),
    // Pass your config
    facetsConfig: facetsConfig,
    // Enable the Taxonomy sidecar index, required for Heirachy facets
    useTaxonomyIndex: true
    );


var searcher = myIndex.Searcher;
var results = searcher.CreateQuery()
    .DrillDownQuery(
        dims =>
        {
            // Specify the dimensions to drill down on
            dims.AddDimension("Author", "Lisa");
        },
        null // Optional base query to drill down over
        ,
        sideways =>
        {
            // Drill Sideways for the top 10 facets
            sideways.SetTopN(10);
        },
        BooleanOperation.Or // Default operation for boolean subqueries
        )
        .WithFacets((Action<IFacetOperations>)(facets =>
        {
            //Fetch the facets
            facets.FacetString("publishDate", x => x.MaxCount(10));
            facets.FacetString("Author", x => x.MaxCount(10));
        }));
    .Execute();

var publishDateResults = results.GetFacet("publishDate"); // Returns the facets for the specific field publishDate
var AuthorFacetResults = results.GetFacet("Author"); // Returns the facets for the specific field publishDate
```

#### Basic BaseQuery example

```csharp
// Setup
// Create a config
var facetsConfig = new FacetsConfig();
facetConfigs.SetHierarchical("publishDate", true);

services.AddExamineLuceneIndex("MyIndex",
    // Set the indexing of your fields to use the facet type
    fieldDefinitions: new FieldDefinitionCollection(
        new FieldDefinition("publishDate", FieldDefinitionTypes.FacetTaxonomyFullText),
        new FieldDefinition("Author", FieldDefinitionTypes.FacetTaxonomyFullText)
        ),
    // Pass your config
    facetsConfig: facetsConfig,
    // Enable the Taxonomy sidecar index, required for Heirachy facets
    useTaxonomyIndex: true
    );


var searcher = myIndex.Searcher;
var results = searcher.CreateQuery()
    .DrillDownQuery(
        dims =>
        {
            // Specify the dimensions to drill down on
            dims.AddDimension("Author", "Lisa");
        },
         baseQuery => // Optional base query to drill down over
        {
            return baseQuery.Field(ExamineFieldNames.CategoryFieldName, "content");
        } 
        ,
        sideways =>
        {
            // Drill Sideways for the top 10 facets
            sideways.SetTopN(10);
        },
        BooleanOperation.Or // Default operation for boolean subqueries
        )
        .WithFacets((Action<IFacetOperations>)(facets =>
        {
            //Fetch the facets
            facets.FacetString("publishDate", x => x.MaxCount(10));
            facets.FacetString("Author", x => x.MaxCount(10));
        }));
    .Execute();

var publishDateResults = results.GetFacet("publishDate"); // Returns the facets for the specific field publishDate
var AuthorFacetResults = results.GetFacet("Author"); // Returns the facets for the specific field publishDate
```