### PR TITLE
Adds new Fluent API Test to highlight issue between Fluent & NativeQuery

### DIFF
--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -19,7 +19,7 @@ namespace Examine.Test.Examine.Lucene.Search
 {
     [TestFixture]
     public class FluentApiTests : ExamineBaseTest
-    {        
+    {
         [Test]
         public void Fluent_And_Native_Return_Different_Results()
         {
@@ -29,12 +29,14 @@ namespace Examine.Test.Examine.Lucene.Search
             {
                 indexer.IndexItems(new[] {
                     ValueSet.FromObject(1.ToString(), "content",
-                        new { nodeName = "location 1", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "Glasgow, Scotland, UK" }),
+                        new { nodeName = "location 1", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "Glasgow, Scotland, United Kingdom" }),
                     ValueSet.FromObject(2.ToString(), "content",
-                        new { nodeName = "location 2", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "England, UK" }),
+                        new { nodeName = "location 2", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "Manchester, England, United Kingdom" }),
                     ValueSet.FromObject(3.ToString(), "content",
-                        new { nodeName = "location 3", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "Edinburgh, Scotland, UK" })
-                    });
+                        new { nodeName = "location 3", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "Edinburgh, Scotland, United Kingdom" }),
+                    ValueSet.FromObject(3.ToString(), "content",
+                        new { nodeName = "location 4", __NodeTypeAlias = "wviewlibrary", wWpPropLibraryAddress = "Birmingham, Alabama, United States" })
+                });
 
                 var searcher = (BaseLuceneSearcher)indexer.Searcher;
 

--- a/src/Examine.Test/ExamineExtensions.cs
+++ b/src/Examine.Test/ExamineExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Xml.Linq;
+using Examine.Search;
 
 namespace Examine
 {
@@ -155,6 +156,15 @@ namespace Examine
                 }
             }
             return elementValues;
+        }
+
+        // Same as one in Umbraco CMS
+        public static IBooleanOperation NodeTypeAlias(this IQuery query, string nodeTypeAlias)
+        {
+            IBooleanOperation? fieldQuery = query.Field(
+                ExamineFieldNames.ItemTypeFieldName,
+                (IExamineValue)new ExamineValue(Examineness.Explicit, nodeTypeAlias));
+            return fieldQuery;
         }
     }
 }


### PR DESCRIPTION
Here you go @Shazwazza 
Here is a PR to support the issue/discussion/question asked in https://github.com/Shazwazza/Examine/issues/375

This is a fluent API test to highlight the issue between Fluent API not using the same exact query when you use it with `NativeQuery()`
