### PR TITLE
V4.0 Lucene 4.8.0-beta00017 breaking changes

### DIFF
--- a/src/Examine.Lucene/Examine.Lucene.csproj
+++ b/src/Examine.Lucene/Examine.Lucene.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Lucene.Net.QueryParser">
-      <Version>4.8.0-beta00016</Version>
+      <Version>4.8.0-beta00017</Version>
     </PackageReference>
-    <PackageReference Include="Lucene.Net.Replicator" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Replicator" Version="4.8.0-beta00017" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Examine.Lucene/ExamineTaxonomyReplicator.cs
+++ b/src/Examine.Lucene/ExamineTaxonomyReplicator.cs
@@ -95,7 +95,12 @@ namespace Examine.Lucene
             IndexAndTaxonomyRevision rev;
             try
             {
-                rev = new IndexAndTaxonomyRevision(_sourceIndex.IndexWriter.IndexWriter, _sourceIndex.TaxonomyWriter as SnapshotDirectoryTaxonomyWriter);
+                var factory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
+                var indexWriter = factory.OpenIndexWriter(
+                    _destinationDirectory,
+                    factory.CreateIndexWriterConfig(OpenMode.CREATE_OR_APPEND));
+
+                rev = new IndexAndTaxonomyRevision(indexWriter, factory);
             }
             catch (InvalidOperationException)
             {
@@ -159,7 +164,13 @@ namespace Examine.Lucene
                     _logger.LogDebug("{IndexName} committed", index.Name);
                 }
             }
-            var rev = new IndexAndTaxonomyRevision(_sourceIndex.IndexWriter.IndexWriter, _sourceIndex.TaxonomyWriter as SnapshotDirectoryTaxonomyWriter);
+
+            var factory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
+            var indexWriter = factory.OpenIndexWriter(
+                _sourceIndex.GetLuceneDirectory(),
+                factory.CreateIndexWriterConfig(OpenMode.CREATE_OR_APPEND));
+
+            var rev = new IndexAndTaxonomyRevision(indexWriter, factory);
             _replicator.Publish(rev);
         }
 

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -21,6 +21,7 @@ using Examine.Lucene.Directories;
 using Lucene.Net.Facet.Taxonomy;
 using Lucene.Net.Facet.Taxonomy.Directory;
 using static Lucene.Net.Replicator.IndexAndTaxonomyRevision;
+using Lucene.Net.Replicator;
 
 namespace Examine.Lucene.Providers
 {
@@ -1285,9 +1286,9 @@ namespace Examine.Lucene.Providers
             {
                 throw new ArgumentNullException(nameof(d));
             }
-            var taxonomyWriter = new SnapshotDirectoryTaxonomyWriter(d);
 
-            return taxonomyWriter;
+            var factory = new SnapshotDirectoryTaxonomyIndexWriterFactory();
+            return new DirectoryTaxonomyWriter(factory, d);
         }
 
         /// <summary>

--- a/src/Examine.Test/Examine.Test.csproj
+++ b/src/Examine.Test/Examine.Test.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.15.1" />
     <PackageReference Include="Lucene.Net.Spatial">
-      <Version>4.8.0-beta00016</Version>
+      <Version>4.8.0-beta00017</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />


### PR DESCRIPTION
I've attempted to address the problems raised in #401, relating to breaking changes in the version `4.8.0-beta00017` Lucene packages.

The code now compiles with the beta00017 packages, utilizing the `SnapshotDirectoryTaxonomyIndexWriterFactory` class from Lucene, however there are three unit tests that now fail which previously succeeded. These are:

- `GivenASyncedLocalIndex_WhenTriggered_ThenSyncedBackToMainIndex`
- `GivenASyncedLocalIndex_ThenSyncedBackToMainIndexOnSchedule`
- `GivenAMainIndex_WhenReplicatedLocally_TheLocalIndexIsPopulated`

The problem lies in the changed implementation of the `ReplicateIndex` method, as I have been unable to figure out exactly how to get it working properly. It now throws `System.InvalidOperationException: 'No index commit to snapshot'`, which results in the method returning early before it can fully completing the work of the method.

I hope I've done a bit of the work, perhaps someone else more knowledgeable can fix up the remaining outstanding problems.