### PR TITLE
Persist all options properties in AddExamineLuceneIndex

### DIFF
--- a/src/Examine.Host/ServicesCollectionExtensions.cs
+++ b/src/Examine.Host/ServicesCollectionExtensions.cs
@@ -60,9 +60,9 @@ namespace Examine
                     name,
                     (options) =>
                     {
-                        options.Analyzer = analyzer;
-                        options.Validator = validator;
-                        options.IndexValueTypesFactory = indexValueTypesFactory;
+                        options.Analyzer = analyzer ?? options.Analyzer;
+                        options.Validator = validator ?? options.Validator;
+                        options.IndexValueTypesFactory = indexValueTypesFactory ?? options.IndexValueTypesFactory;
                         options.FieldDefinitions = fieldDefinitions ?? options.FieldDefinitions;
                         options.DirectoryFactory = services.GetRequiredService<TDirectoryFactory>();
                     }));


### PR DESCRIPTION
I've been trying to track down a strange bug affecting my [Umbraco Search Extensions](https://github.com/callumbwhyte/umbraco-search-extensions) project.

When configuring `LuceneDirectoryIndexOptions` certain properties are always null, regardless if a previous configurator (`IConfigureNamedOptions`) ran and set the values.

```
public class ConfigureIndexOptionsFirst : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
{
    public void Configure(string? name, LuceneDirectoryIndexOptions options)
    {
        // null here (unless explicitly set when calling AddExamineLuceneIndex)
        options.IndexValueTypesFactory = new Dictionary<string, IFieldValueTypeFactory>();
    }
}
```

```
public class ConfigureIndexOptionsLast : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
{
    public void Configure(string? name, LuceneDirectoryIndexOptions options)
    {
        // options.IndexValueTypesFactory is null here
    }
}
```

```
builder.Services.ConfigureOptions<ConfigureIndexOptionsFirst>();

builder.Services.ConfigureOptions<ConfigureIndexOptionsLast>();
```

It seems when `LuceneDirectoryIndexOptions` is initially registered, most values are always set to parameters passed in to the `AddExamineLuceneIndex` method – for which most are null by default. This code runs for each new configurator, effectively wiping out the previous configuration on each run, and therefore the last configurator to run will always win.

This is particularly problematic for in my case where I want to register a bunch of default index value types but also encourage the consumer to register their own.

Let me know if there's something obvious I'm missing here...! PR targets v3 but also applies to v4.