### PR TITLE
(v4) Persist all options properties in AddExamineLuceneIndex

### DIFF
--- a/src/Examine.Host/ServicesCollectionExtensions.cs
+++ b/src/Examine.Host/ServicesCollectionExtensions.cs
@@ -38,12 +38,12 @@ namespace Examine
                     name,
                     (options) =>
                     {
-                        options.Analyzer = config.Analyzer;
-                        options.Validator = config.Validator;
-                        options.IndexValueTypesFactory = config.IndexValueTypesFactory;
-                        options.FieldDefinitions = config.FieldDefinitions ?? options.FieldDefinitions;
-                        options.DirectoryFactory = services.GetRequiredService<TDirectoryFactory>();
-                        options.FacetsConfig = config.FacetsConfig ?? new FacetsConfig();
+                        options.Analyzer = options.Analyzer ?? config.Analyzer;
+                        options.Validator = options.Validator ?? config.Validator;
+                        options.IndexValueTypesFactory = options.IndexValueTypesFactory ?? config.IndexValueTypesFactory;
+                        options.FieldDefinitions = options.FieldDefinitions ?? config.FieldDefinitions;
+                        options.DirectoryFactory = options.DirectoryFactory ?? services.GetRequiredService<TDirectoryFactory>();
+                        options.FacetsConfig = options.FacetsConfig ?? config.FacetsConfig ?? new FacetsConfig();
                     }));
 
             return serviceCollection.AddSingleton<IIndex>(services =>
@@ -98,8 +98,8 @@ namespace Examine
                     name,
                     (options) =>
                     {
-                        options.Analyzer = config.Analyzer;
-                        options.FacetConfiguration = config.FacetConfiguration;
+                        options.Analyzer = options.Analyzer ?? config.Analyzer;
+                        options.FacetConfiguration = options.FacetConfiguration ?? config.FacetConfiguration;
                     }));
 
             // Transient I think because of how the search context is created, it can't hang on to it.


### PR DESCRIPTION
Same change as on #423 but for Examine v4!

When configuring `LuceneDirectoryIndexOptions` certain properties are always null, regardless if a previous configurator (`IConfigureNamedOptions`) ran and set the values.

When `LuceneDirectoryIndexOptions` is initially registered, most values are always set to parameters passed in to the AddExamineLuceneIndex method – for which most are null by default. This code runs for each new configurator, effectively wiping out the previous configuration on each run, and therefore the last configurator to run will always win.