### PR TITLE
Backport: Fix SearchableFields caching and CommitNow race condition (#426, #427)

### DIFF
--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -283,11 +283,8 @@ namespace Examine.Lucene.Providers
                     //this is required to ensure the index is written to during the same thread execution
                     if (!RunAsync)
                     {
-                        //commit the changes
+                        //commit the changes (also refreshes NRT reader and fires IndexCommitted)
                         _committer.CommitNow();
-
-                        // now force any searcher to be updated.
-                        WaitForChanges();
                     }
                     else
                     {
@@ -515,11 +512,8 @@ namespace Examine.Lucene.Providers
                 //this is required to ensure the index is written to during the same thread execution
                 if (!RunAsync)
                 {
-                    //commit the changes (this will process the deletes too)
+                    //commit the changes (also refreshes NRT reader and fires IndexCommitted)
                     _committer.CommitNow();
-
-                    // now force any searcher to be updated.
-                    WaitForChanges();
                 }
                 else
                 {

--- a/src/Examine.Lucene/Providers/LuceneIndex.cs
+++ b/src/Examine.Lucene/Providers/LuceneIndex.cs
@@ -794,6 +794,12 @@ namespace Examine.Lucene.Providers
             public void CommitNow()
             {
                 _index._writer?.IndexWriter?.Commit();
+
+                // Ensure the NRT reader is refreshed before signaling commit completion.
+                // Without this, consumers reacting to IndexCommitted may search with
+                // a stale reader that doesn't yet reflect the committed changes.
+                _index.WaitForChanges();
+
                 _index.IndexCommitted?.Invoke(_index, EventArgs.Empty);
             }
 
@@ -864,9 +870,6 @@ namespace Examine.Lucene.Providers
                         {
                             //perform the commit
                             CommitNow();
-
-                            // after the commit, refresh the searcher
-                            _index.WaitForChanges();
                         }
                         catch (Exception e)
                         {

--- a/src/Examine.Lucene/Search/SearchContext.cs
+++ b/src/Examine.Lucene/Search/SearchContext.cs
@@ -57,9 +57,18 @@ namespace Examine.Lucene.Search
                                     .ToList();
 
                         //exclude the special index fields
-                        _searchableFields = fields
+                        var filtered = fields
                             .Where(x => !x.StartsWith(ExamineFieldNames.SpecialFieldPrefix))
                             .ToArray();
+
+                        // Only cache non-empty results so that an initially empty index
+                        // will re-read fields once documents have been indexed.
+                        if (filtered.Length > 0)
+                        {
+                            _searchableFields = filtered;
+                        }
+
+                        return filtered;
                     }
                     finally
                     {


### PR DESCRIPTION
## Summary

Backports two bug fixes from the v4 branch to support/3.x. Both bugs were discovered during Umbraco.Cms.Search compatibility testing.

## Fixes

### 1. SearchableFields caches empty result from initially empty index (#426)

**File:** `src/Examine.Lucene/Search/SearchContext.cs`

`SearchContext.SearchableFields` caches its result after the first read. If accessed before any documents are indexed (e.g., during startup when `ExamineMultiFieldQueryParser` is constructed), an empty array is cached permanently. After documents are indexed, `IsSearcherCurrent()` returns `true` so the `SearchContext` is never recreated, leaving `Search(string)` / `ManagedQuery()` with zero fields to search against.

**Fix:** Only cache when the result is non-empty.

### 2. Race condition: IndexCommitted fires before NRT reader refresh (#427)

**File:** `src/Examine.Lucene/Providers/LuceneIndex.cs` (nested `IndexCommiter` class)

In the async commit path (`TimerRelease`), `CommitNow()` fires `IndexCommitted` before `WaitForChanges()` refreshes the NRT reader. Consumers reacting to the event may search with a stale reader.

**Fix:** Move `WaitForChanges()` into `CommitNow()` before firing the event.

## Testing

- All 142 v3 tests pass on net8.0 (the pre-existing `ContentDeliveryApiTests.cs` build error is unrelated — it uses v4-only APIs)
- Both fixes were validated on v4 with full Umbraco.Cms.Search integration tests (628 passed, 0 failed)