### PR TITLE
Fix fieldValue argument exception

### DIFF
--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -297,7 +297,7 @@ namespace Examine.Lucene.Search
 
             if (string.IsNullOrEmpty(fieldValue.Value))
             {
-                throw new ArgumentException($"'{nameof(fieldName)}' cannot be null or empty", nameof(fieldName));
+                throw new ArgumentException($"'{nameof(fieldValue)}' cannot be null or empty", nameof(fieldValue));
             }
 
             Query queryToAdd;

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -91,6 +91,22 @@ namespace Examine.Test.Examine.Lucene.Search
         }
 
         [Test]
+        public void Field_With_Empty_Value_Throws_For_FieldValue()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using (var luceneDir = new RandomIdRAMDirectory())
+            using (var indexer = GetTestIndex(luceneDir, analyzer))
+            {
+                var searcher = indexer.Searcher;
+
+                var ex = Assert.Throws<ArgumentException>(() =>
+                    searcher.CreateQuery("content").Field("nodeName", string.Empty));
+
+                Assert.AreEqual("fieldValue", ex.ParamName);
+            }
+        }
+
+        [Test]
         public void NativeQuery_Single_Word()
         {
             var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);


### PR DESCRIPTION
## Summary

- Correct the empty `fieldValue` guard so the exception reports `fieldValue` instead of `fieldName`.
- Add coverage for the fluent `Field` API argument name.

Fixes #415

## Tests

- `dotnet test src/Examine.Test/Examine.Test.csproj --framework net6.0 --filter FullyQualifiedName~Examine.Test.Examine.Lucene.Search.FluentApiTests`
- `dotnet test src/Examine.Test/Examine.Test.csproj --framework net8.0 --filter FullyQualifiedName~Examine.Test.Examine.Lucene.Search.FluentApiTests`
