### PR TITLE
Safeguard against null queries before applying boost factor

### DIFF
--- a/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
+++ b/src/Examine.Lucene/Search/LuceneSearchQueryBase.cs
@@ -455,6 +455,13 @@ namespace Examine.Lucene.Search
                     break;
             }
 
+            // Lucene.Net does not have Nullable enabled, but the MultiFieldQueryParser can actually return a
+            // null query. Let's make sure it's handled, before we continue to work with the query.
+            if (queryToAdd is null)
+            {
+                return null;
+            }
+
             if (fieldValue is IExamineValueBoosted boostedValue)
             {
                 queryToAdd.Boost = boostedValue.Boost;

--- a/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
+++ b/src/Examine.Test/Examine.Lucene/Search/FluentApiTests.cs
@@ -5361,5 +5361,26 @@ namespace Examine.Test.Examine.Lucene.Search
             var secondResults = results2.ToArray();
             Assert.IsFalse(firstResults.Any(x => secondResults.Any(y => y.Id == x.Id)), "The second set of results should not contain the first set of results");
         }
+
+        [Test]
+        public void Boosted_Field_Query_Stop_Words_Only()
+        {
+            var analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
+            using var luceneDir = new RandomIdRAMDirectory();
+            using var luceneTaxonomyDir = new RandomIdRAMDirectory();
+            using var indexer = GetTestIndex(luceneDir, luceneTaxonomyDir, analyzer);
+            indexer.IndexItems([ValueSet.FromObject(1.ToString(), "content", new { bodyText = "Something to index" })]);
+
+            var searcher = indexer.Searcher;
+            IBooleanOperation? query = null;
+
+            // create a boosted field query that contains only stop words
+            Assert.DoesNotThrow(() => query = searcher
+                .CreateQuery(category: "content")
+                .Field("bodyText", "this".Boost(10)));
+
+            var results = query!.Execute();
+            Assert.AreEqual(0, results!.TotalItemCount);
+        }
     }
 }


### PR DESCRIPTION
The Lucene.Net `MultiFieldQueryParser` can return `null` values, even if it does not appear to be so, because the Lucene.Net project apparently builds with `Nullable` disabled.

I've added a safeguard to exit early, before applying boost to a `null` value.

## Steps to recreate

Perform a boosted field query on a stop word. This causes a `null` return value from `MultiFieldQueryParser` ([this line](https://github.com/apache/lucenenet/blob/docs/4.8.0-beta00017/src/Lucene.Net.QueryParser/Classic/MultiFieldQueryParser.cs#L173)). The subsequent attempt to apply boost factor to the query throws a null reference exception.