### PR TITLE
Reintroduce `LuceneQueryOptions` constructor for backwards compat

### DIFF
--- a/src/Examine.Lucene/PublicAPI.Unshipped.txt
+++ b/src/Examine.Lucene/PublicAPI.Unshipped.txt
@@ -185,7 +185,6 @@ virtual Examine.Lucene.Search.TaxonomySearcherReference.Dispose(bool disposing) 
 *REMOVED*Examine.Lucene.Providers.MultiIndexSearcher.MultiIndexSearcher(string name, System.Collections.Generic.IEnumerable<Examine.IIndex> indexes, Lucene.Net.Analysis.Analyzer analyzer = null) -> void
 *REMOVED*Examine.Lucene.Providers.MultiIndexSearcher.MultiIndexSearcher(string name, System.Lazy<System.Collections.Generic.IEnumerable<Examine.ISearcher>> searchers, Lucene.Net.Analysis.Analyzer analyzer = null) -> void
 *REMOVED*Examine.Lucene.Providers.MultiIndexSearcher.Searchers.get -> System.Collections.Generic.IEnumerable<Examine.Lucene.Providers.LuceneSearcher>
-*REMOVED*Examine.Lucene.Search.LuceneQueryOptions.LuceneQueryOptions(int skip, int? take = null, Examine.Lucene.Search.SearchAfterOptions searchAfter = null, bool trackDocumentScores = false, bool trackDocumentMaxScore = false, int skipTakeMaxResults = 10000, bool autoCalculateSkipTakeMaxResults = false) -> void
 *REMOVED*Examine.Lucene.Search.LuceneSearchResults.LuceneSearchResults(System.Collections.Generic.IReadOnlyCollection<Examine.ISearchResult> results, int totalItemCount, float maxScore, Examine.Lucene.Search.SearchAfterOptions searchAfterOptions) -> void
 *REMOVED*Examine.Lucene.Search.SearchAfterOptions.ShardIndex.get -> int?
 *REMOVED*Examine.Lucene.Search.SearchContext.SearchContext(Lucene.Net.Search.SearcherManager searcherManager, Examine.Lucene.FieldValueTypeCollection fieldValueTypeCollection) -> void

--- a/src/Examine.Lucene/Search/LuceneQueryOptions.cs
+++ b/src/Examine.Lucene/Search/LuceneQueryOptions.cs
@@ -39,6 +39,37 @@ namespace Examine.Lucene.Search
         }
 
         /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="skip">Number of result documents to skip.</param>
+        /// <param name="take">Optional number of result documents to take.</param>
+        /// <param name="searchAfter">Optionally skip to results after the results from the previous search execution. Used for efficent deep paging.</param>
+        /// <param name="trackDocumentMaxScore">Whether to track the maximum document score. For best performance, if not needed, leave false.</param>
+        /// <param name="skipTakeMaxResults">When using Skip/Take (not SearchAfter) this will be the maximum data set size that can be paged.</param>
+        /// <param name="autoCalculateSkipTakeMaxResults">If enabled, this will pre-calculate the document count in the index to use for <see cref="SkipTakeMaxResults"/>.</param>
+        /// <param name="trackDocumentScores">Whether to Track Document Scores. For best performance, if not needed, leave false.</param>
+        [Obsolete("To remove in Examine 5.0")]
+        public LuceneQueryOptions(
+            int skip,
+            int? take = null,
+            SearchAfterOptions? searchAfter = null,
+            bool trackDocumentScores = false,
+            bool trackDocumentMaxScore = false,
+            int skipTakeMaxResults = AbsoluteMaxResults,
+            bool autoCalculateSkipTakeMaxResults = false)
+            : this(
+                skip,
+                take ?? DefaultMaxResults,
+                searchAfter,
+                trackDocumentScores,
+                trackDocumentMaxScore,
+                skipTakeMaxResults,
+                autoCalculateSkipTakeMaxResults,
+                facetSampling: null)
+        {
+        }
+
+        /// <summary>
         /// Whether to Track Document Scores. For best performance, if not needed, leave false.
         /// </summary>
         public bool TrackDocumentScores { get; }


### PR DESCRIPTION
Umbraco CMS currently relies on a `LuceneQueryOptions` constructor ([here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs#L83)) which has been removed in Examine 4. This is the root cause of https://github.com/umbraco/Umbraco.Cms.Search/issues/169.

I have reintroduced the removed constructor and tagged it as obsolete. Hopefully this will allow Umbraco CMS to run Examine 4.