### PR TITLE
Bump Microsoft/System packages 10.0.7 -> 10.0.11 to fix NU1903 build failure

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,13 +13,13 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
 
     <!-- Microsoft.Extensions -->
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
 
     <!-- Lucene.Net -->
     <PackageVersion Include="Lucene.Net.QueryParser" Version="4.8.0-beta00017" />
@@ -27,7 +27,7 @@
     <PackageVersion Include="Lucene.Net.Spatial" Version="4.8.0-beta00017" />
 
     <!-- System -->
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.11" />
 
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />


### PR DESCRIPTION
## Problem

The `Examine Build` workflow on `release/4.0` is failing (e.g. run 31533628967).

`src/Directory.Build.props` sets `TreatWarningsAsErrors=true`, so the NuGet audit warning **NU1903** becomes a build error.

`Microsoft.AspNetCore.DataProtection` 10.0.7 transitively resolved `System.Security.Cryptography.Xml` 10.0.7, which is affected by newly published advisories:

| Advisory | CVE |
| --- | --- |
| GHSA-23rf-6693-g89p | CVE-2026-50648 |
| GHSA-8q5v-6pqq-x66h | CVE-2026-50525 |
| GHSA-cvvh-rhrc-wg4q | CVE-2026-47302 |
| GHSA-g8r8-53c2-pm3f | CVE-2026-47304 |
| GHSA-mmjf-rqrv-855v | CVE-2026-50527 |

These affect `>= 10.0.0, <= 10.0.9`. First patched version is 10.0.10; latest on nuget.org is 10.0.11.

## Fix

Bump every Microsoft/System package pinned at `10.0.7` in `src/Directory.Packages.props` to `10.0.11`:

- Microsoft.AspNetCore.DataProtection
- Microsoft.Extensions.DependencyInjection.Abstractions
- Microsoft.Extensions.Hosting
- Microsoft.Extensions.Logging
- Microsoft.Extensions.Logging.Abstractions
- Microsoft.Extensions.Logging.Console
- Microsoft.Extensions.Options
- System.Configuration.ConfigurationManager

`Microsoft.AspNetCore.DataProtection` 10.0.11 depends on `System.Security.Cryptography.Xml` 10.0.11, resolving all advisories.

No NuGet audit suppressions or `NoWarn` entries were added, and no unrelated package versions were changed. `src/Directory.Packages.props` was the only file in the repo pinning `10.0.7`.

## Verification

- `dotnet restore src/Examine.sln` — succeeds; `project.assets.json` now resolves `System.Security.Cryptography.Xml/10.0.11`.
- `dotnet build src/Examine.Test/Examine.Test.csproj --configuration Release --framework net10.0` — **Build succeeded, 0 Warning(s), 0 Error(s)**. No NU1903.