### PR TITLE
Reintroduce `FileSystemDirectoryFactory` constructor for backwards compat

### DIFF
--- a/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs
+++ b/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs
@@ -29,6 +29,17 @@ namespace Examine.Lucene.Directories
         }
 
         /// <summary>
+        /// Creates an instance of <see cref="FileSystemDirectoryFactory"/>
+        /// </summary>
+        [Obsolete("To remove in Examine 5.0")]
+        public FileSystemDirectoryFactory(
+            DirectoryInfo baseDir,
+            ILockFactory lockFactory)
+            : this (baseDir, lockFactory, new FakeLuceneDirectoryIndexOptionsOptionsMonitor())
+        {
+        }
+
+        /// <summary>
         /// The factory for creating locks
         /// </summary>
         public ILockFactory LockFactory { get; }
@@ -65,13 +76,13 @@ namespace Examine.Lucene.Directories
         public virtual Directory? CreateTaxonomyDirectory(LuceneIndex luceneIndex, bool forceUnlock)
         {
             var options = IndexOptions.GetNamedOptions(luceneIndex.Name);
-            
+
             // If taxonomy is not enabled, return null
             if (!options.UseTaxonomyIndex)
             {
                 return null;
             }
-            
+
             var path = Path.Combine(_baseDir.FullName, luceneIndex.Name, "taxonomy");
             var luceneIndexFolder = new DirectoryInfo(path);
 

--- a/src/Examine.Lucene/PublicAPI.Unshipped.txt
+++ b/src/Examine.Lucene/PublicAPI.Unshipped.txt
@@ -169,7 +169,6 @@ virtual Examine.Lucene.Providers.LuceneIndex.TaxonomySearcher.get -> Examine.Luc
 virtual Examine.Lucene.Search.LuceneFacetExtractionContext.GetFacetCounts(string! facetIndexFieldName, bool isTaxonomyIndexed) -> Lucene.Net.Facet.Facets!
 virtual Examine.Lucene.Search.LuceneSearchQueryBase.GetFieldInternalQuery(string! fieldName, Examine.Search.IExamineValue! fieldValue) -> Lucene.Net.Search.Query?
 virtual Examine.Lucene.Search.TaxonomySearcherReference.Dispose(bool disposing) -> void
-*REMOVED*Examine.Lucene.Directories.FileSystemDirectoryFactory.FileSystemDirectoryFactory(System.IO.DirectoryInfo baseDir, Examine.Lucene.Directories.ILockFactory lockFactory) -> void
 *REMOVED*Examine.Lucene.Directories.SyncedFileSystemDirectoryFactory.SyncedFileSystemDirectoryFactory(System.IO.DirectoryInfo localDir, System.IO.DirectoryInfo mainDir, Examine.Lucene.Directories.ILockFactory lockFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, bool tryFixMainIndexIfCorrupt) -> void
 *REMOVED*Examine.Lucene.Directories.SyncedFileSystemDirectoryFactory.SyncedFileSystemDirectoryFactory(System.IO.DirectoryInfo localDir, System.IO.DirectoryInfo mainDir, Examine.Lucene.Directories.ILockFactory lockFactory, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) -> void
 *REMOVED*Examine.Lucene.Directories.TempEnvFileSystemDirectoryFactory.TempEnvFileSystemDirectoryFactory(Examine.Lucene.Directories.IApplicationIdentifier applicationIdentifier, Examine.Lucene.Directories.ILockFactory lockFactory) -> void


### PR DESCRIPTION
Umbraco CMS currently relies on a `FileSystemDirectoryFactory` constructor ([here](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.Examine.Lucene/UmbracoTempEnvFileSystemDirectoryFactory.cs#L12)) which has been removed in Examine 4.

For comparison, here are the `FileSystemDirectoryFactory` constructors for [Examine 3](https://github.com/Shazwazza/Examine/blob/support/3.x/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs) and [Examine 4](https://github.com/Shazwazza/Examine/blob/release/4.0/src/Examine.Lucene/Directories/FileSystemDirectoryFactory.cs), respectively. The obsolete marked constructor from Examine 3 has been removed in Examine 4, which is fair - but it rather breaks the current versions of Umbraco CMS.

I have reintroduced the removed constructor and tagged it as obsolete for Examine 5.

See also #550

